### PR TITLE
fix: reliable Epic/Steam auto-claim + tests (v2.4.0)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,66 @@
+# CLAUDE.md
+
+Guidance for Claude Code when working in this repository.
+
+## What this is
+
+A cross-browser (Chrome + Firefox) **WebExtension** that automatically claims free
+games from the Epic Games Store and surfaces free Steam games. Built with
+**WXT** (Web Extension Toolkit), **React 19**, and **TypeScript**.
+
+## Where the code lives
+
+⚠️ The actual project is in the **`wxt-dev-wxt/`** subdirectory, not the repo root.
+Run all commands from there:
+
+```bash
+cd wxt-dev-wxt
+```
+
+The repo root only holds the README, images, and a stub `package.json`.
+
+## Commands (run inside `wxt-dev-wxt/`)
+
+| Task | Command |
+|------|---------|
+| Install deps | `npm install` |
+| Dev (Chrome) | `npm run dev` |
+| Dev (Firefox) | `npm run dev:firefox` |
+| Build (Chrome) | `npm run build` |
+| Build (Firefox) | `npm run build:firefox` |
+| Type-check | `npm run compile` (`tsc --noEmit`) — **clean, 0 errors** |
+| Test | `npm test` (Vitest, `test:watch` for watch mode) |
+| Package zip | `npm run zip` / `npm run zip:firefox` |
+
+**Verification gates (all must stay green):** `npm run compile` (type-check), `npm test`
+(Vitest), and `npm run build` (`wxt build`). No linter is configured.
+
+Tests use WXT's Vitest integration (`WxtVitest`), which mocks `#imports`/`browser`/`storage`.
+DOM-dependent suites run under `jsdom`; storage suites use `// @vitest-environment node` to
+avoid an esbuild/jsdom `TextEncoder` clash. Test files live next to sources as `*.test.ts`.
+
+> Note: both `package-lock.json` and `pnpm-lock.yaml` are present. The README documents
+> npm; prefer `npm` unless told otherwise, and don't add a second lockfile's worth of churn.
+
+## Project structure (`wxt-dev-wxt/entrypoints/`)
+
+- `background.ts` — service worker: Epic/Steam fetching, alarms-based scheduling, claim logic
+- `epic.content.ts` / `steam.content.ts` — content scripts injected on store pages
+- `popup/` — React popup UI (`App.tsx`, `main.tsx`)
+- `components/` — React components (Settings, GamesList, GameCard, FrequencySelect, …)
+- `hooks/useStorage.ts` — typed wrapper over `browser.storage`
+- `types/` — shared TypeScript types
+- `enums/` — `claimFrequency`, `platforms`, `activeTabs`, `storageValues`
+- `utils/` — `helpers.ts`, `oncePerPageRun.ts`
+- `wxt.config.ts` — manifest, permissions, browser targets. `@/*` aliases the project root.
+
+## Conventions
+
+- **Path alias:** import via `@/entrypoints/...` (mapped to `wxt-dev-wxt/`).
+- **Immutability:** create new objects/state rather than mutating in place.
+- **Commits:** prefer Conventional Commits (`feat:`, `fix:`, `refactor:`, `docs:`, `chore:`).
+  History is mixed (many bare subjects), but new work should follow the convention.
+- **PR workflow:** feature branches (e.g. `feat/<topic>`) merged via PR with **merge commits**
+  (history is not squashed).
+- **Browser APIs:** use the `browser` namespace from `wxt/browser` (not raw `chrome`).
+- Extension `permissions`/`host_permissions` live in `wxt.config.ts` — keep them minimal.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,74 @@
+# Architecture
+
+> Consolidated ECC architecture doc. Covers overall architecture, module responsibilities,
+> data flow, state management, networking, and persistence.
+
+## Overall shape
+
+A standard **WXT / Manifest V3 WebExtension** with three runtime surfaces that communicate
+via `browser.runtime` message passing. There is **no server** — all logic is client-side.
+
+```
+┌─────────────────┐   messages    ┌──────────────────────┐   messages   ┌──────────────────┐
+│  Popup (React)  │◀────────────▶│  Background (SW)      │◀───────────▶│  Content scripts  │
+│  Settings/List  │   target:     │  scheduler + claim    │   target:    │  epic / steam     │
+│                 │   background   │  orchestrator         │  content     │  DOM automation   │
+└────────┬────────┘               └──────────┬───────────┘              └────────┬─────────┘
+         │                                    │                                   │
+         └──────────── browser.storage.local (shared state) ───────────────────┘
+```
+
+## Major modules & responsibilities
+
+| Module | File | Responsibility |
+|--------|------|----------------|
+| **Background** | `entrypoints/background.ts` (400 LOC) | Core orchestrator. Alarm scheduling, frequency logic, Epic API fetch, Steam HTML fetch, diffing new games, opening claim tabs, badge text, Steam MAIN-world `addToCart` injection. |
+| **Epic content** | `entrypoints/epic.content.ts` | Runs on `store.epicgames.com/*`. Scrapes free-game cards, detects login state, drives the purchase-CTA + iframe payment-confirm flow. |
+| **Steam content** | `entrypoints/steam.content.ts` | Runs on `store.steampowered.com/*`. Scrapes `-100%` free games, drives add-to-account (special-cases Steam's `javascript:addToCart()` URL via a background message). |
+| **Popup UI** | `entrypoints/popup/` + `components/` | React 19 popup: `Settings`, `GamesList`/`GameCard`, `FrequencySelect`, `OnButton`, `ManualClaimBtn`, `Footer`. |
+| **Storage layer** | `entrypoints/hooks/useStorage.ts` | `useStorage` React hook + `get/set/merge` helpers over WXT `storage`. Namespaces keys as `local:<key>`. |
+| **Helpers** | `entrypoints/utils/helpers.ts` | DOM polling (`waitForElement`), randomized `realClick`, iframe clicking, `incrementCounter`. |
+| **Types / enums** | `entrypoints/types/`, `entrypoints/enums/` | Shared models (`FreeGame`, `EpicSearchResponse`, …) and enums (`ClaimFrequency`, `Platforms`, `StorageValues`, `ActiveTabs`). |
+
+## Data flow — a claim cycle
+
+1. **Trigger:** `browser.alarms` fires (`checkFreeGames`) or `onStartup`, or the user clicks
+   "Manually claim" (popup → background `action: "claim"`).
+2. **Due check:** `checkAndClaimIfDue()` compares `lastOpened` against the frequency
+   (`ClaimFrequencyMinutes`) using an `isChecking` re-entrancy guard.
+3. **Fetch:**
+   - **Epic:** `fetch(EPIC_API_URL)` → JSON → filter `discountPrice === 0` + active promo.
+   - **Steam:** `fetch(STEAM_GAMES_URL)` → HTML → `node-html-parser` → scrape result rows.
+   - On fetch failure, falls back to **opening the store page + content-script scrape**.
+4. **Diff:** new games = those whose `title` isn't already in stored `epicGames`/`steamGames`.
+5. **Claim:** for each new game, `openTabAndSendActionToContent(link, "claimGames")` opens a
+   tab, waits for load, and messages the content script to click through the claim UI.
+   A 10s spacer separates claims. Badge text shows the count.
+6. **Counter:** content scripts call `incrementCounter()` → `merge` into `counter` storage.
+
+## State management & persistence
+
+- **Single source of truth:** `browser.storage.local`, keyed `local:<name>`.
+- **Keys:** `active`, `claimFrequency`, `steamCheck`, `epicCheck`, `lastOpened`, `epicGames`,
+  `steamGames`, `futureGames`, `counter`, `activeTab`.
+- **Popup ↔ storage:** the `useStorage<T>` hook mirrors a storage key into React state and
+  writes back on change (after an init guard to avoid clobbering on first mount).
+- **Background ↔ storage:** direct `get/setStorageItem(s)` calls.
+- No external DB, no auth of its own — it **relies on the user's existing logged-in browser
+  sessions** on Epic/Steam.
+
+## Networking & external dependencies
+
+- **Epic:** `store-site-backend-static-ipv4.ak.epicgames.com/freeGamesPromotions` (public JSON).
+- **Steam:** `store.steampowered.com/search/...` (HTML, scraped).
+- **Host permissions** (`wxt.config.ts`): the Steam store + the Epic backend host.
+- **Manifest permissions:** `storage`, `tabs`, `scripting`, `alarms`.
+
+## Notable design decisions (observed)
+
+- **Dual acquisition strategy** per platform: fast path = direct fetch/scrape from background;
+  fallback = open the real store page and let the content script scrape. Resilient to API/DOM drift.
+- **Randomized delays + synthetic mouse events** in claim flows — mimics human interaction to
+  survive store anti-bot heuristics. **Needs Verification** that this is the explicit intent.
+- **MAIN-world injection** for Steam `addToCart` to call the page's own cart function, working
+  around CSP restrictions on `javascript:` URLs.

--- a/docs/feature_status.md
+++ b/docs/feature_status.md
@@ -1,0 +1,71 @@
+# Feature Status, Technical Debt & Roadmap
+
+> Consolidated ECC doc. Covers feature status, known issues / technical debt, and roadmap.
+
+## Feature status
+
+| Feature | Status | Notes |
+|---------|--------|-------|
+| Epic auto-claim | ✅ Implemented | API fetch + content-script claim flow with iframe payment confirm. |
+| Steam auto-claim | ✅ Implemented | HTML scrape + add-to-account, MAIN-world `addToCart` fallback. |
+| Configurable frequency | ✅ Implemented | Browser-start / hourly / 6h / 12h / daily via `browser.alarms`. |
+| Manual claim | ✅ Implemented | Popup button → background `action: "claim"`. |
+| Platform toggle (Steam/Epic) | ✅ Implemented | `steamCheck` / `epicCheck` storage flags. |
+| Free-games list UI | ✅ Implemented | React popup "Free Games" tab. |
+| Claim counter | ✅ Implemented | `incrementCounter()` → `counter` storage. |
+| Upcoming free games | 🟡 Partial | Epic `futureGames` are stored but surfacing in UI is unconfirmed. **Needs Verification**. |
+| Automated tests | 🟡 Partial | Vitest suite (19 tests) covers storage helpers, `helpers.ts`, and `claimFrequency`. Background/content-script logic still uncovered. |
+
+## Technical debt & known issues (prioritized by impact)
+
+### RESOLVED (this session)
+1. ✅ **`waitForPageLoad()` never waits** (`utils/helpers.ts`) — fixed to `if (!isDocumentReady())`;
+   covered by a regression test that fails on the old code.
+2. ✅ **Unguarded null in Epic diff** (`background.ts`) — now `getStorageItem("epicGames") || []`.
+3. ✅ **`tsc --noEmit` was red (47 errors)** — now **0**. Fixed by extracting the `defineBackground`
+   object to a `const` (restores `this` typing), using the `Browser` type namespace, and branding
+   the `useStorage` keys as `StorageItemKey`.
+4. 🟡 **No tests** — Vitest harness added with 19 tests; background/content-script logic still uncovered.
+
+### HIGH
+- **Content-script logic remains untested.** The money-adjacent claim flows (purchase/add-to-cart
+  clicking) have no coverage. Background methods aren't exported, so testing them needs a small
+  refactor (extract pure helpers like `formatEpicFreeGame`, `areDatesDifferent`).
+
+### MEDIUM
+5. **Two lockfiles committed** (`package-lock.json` + `pnpm-lock.yaml`). Ambiguous package
+   manager → drift risk. Pick one, delete the other.
+5. **`console.log` in production** (`steam.content.ts:53`) — violates the no-console rule and
+   leaks scrape data to the page console.
+6. **Duplicated logic across content scripts.** Epic and Steam scripts share near-identical
+   message-handling and free-game-extraction shapes; extract shared helpers.
+7. **Fragile CSS-hash selectors** (`epic.content.ts:37-38`, e.g. `section.css-2u323`,
+   `a.css-g3jcms`). Epic's generated class names change frequently and will silently break
+   scraping. Consider more stable selectors / attribute-based queries.
+8. **Duplicated `steamAddToCart` fallback logic** between `background.ts` and the injected MAIN
+   world function; and duplicated `wait`/`getRndInteger` between background and helpers.
+
+### LOW
+9. **Nested-project layout** (`wxt-dev-wxt/`) is unusual and easy to trip over; consider
+   flattening or documenting why (done in `CLAUDE.md`).
+10. **`any` usage** in several signatures (`sendMessage`, content `main(_: any)`) — tighten types.
+11. **Stub root `package.json`** with mismatched deps vs. the real one — remove or clarify.
+
+## Security & safety notes
+
+- The extension **automates purchase/claim UI** and injects into `MAIN` world on Steam. This is
+  intentional but inherently sensitive: a selector/logic bug could interact with paid items.
+  Free-game gating relies on `discountPrice === 0` / `-100%` checks — verify these stay correct.
+- Relies on the user's **existing logged-in sessions**; it stores no credentials. Good.
+- No secrets in the codebase (confirmed — no `.env`, no API keys).
+- Randomized delays + synthetic events resemble anti-bot evasion; acceptable for a personal
+  claiming tool the user installs for themselves, but worth a conscious stance. **Needs Verification**.
+
+## Roadmap (suggested, not committed)
+
+- **Short term:** fix the two HIGH bugs; add a minimal test harness (Vitest) around pure logic
+  (`formatEpicFreeGame`, frequency/date math, storage helpers).
+- **Medium term:** resilience for Epic selector drift; consolidate content-script duplication;
+  single package manager; remove `console.log`.
+- **Long term:** consider an E2E smoke test (Playwright) against fixture pages; evaluate whether
+  Steam scraping can move fully to the content-script path to reduce fragility.

--- a/docs/onboarding.md
+++ b/docs/onboarding.md
@@ -1,0 +1,51 @@
+# Onboarding
+
+> Consolidated ECC onboarding doc. Covers **vision**, **purpose**, and **getting started**.
+> Generated from source analysis. Items that could not be confirmed are marked **Needs Verification**.
+
+## Purpose & vision
+
+A cross-browser (Chrome + Firefox) WebExtension that **automatically discovers and claims
+free games** from the Epic Games Store and Steam, so users never miss a free title.
+
+- **Value proposition:** set-and-forget free-game claiming with configurable frequency.
+- **Users:** individual gamers who own Epic/Steam accounts and stay logged in.
+- **Non-goals (inferred):** no backend, no accounts of its own, no telemetry/analytics.
+  Everything runs client-side in the browser. **Needs Verification** (no explicit product doc exists).
+
+## Getting started
+
+⚠️ The project lives in the **`wxt-dev-wxt/`** subdirectory, not the repo root.
+
+```bash
+cd wxt-dev-wxt
+npm install
+npm run dev            # Chrome dev build + hot reload
+npm run dev:firefox    # Firefox dev build
+npm run build          # production build → dist/
+npm run compile        # type-check (tsc --noEmit) — the only verification gate
+```
+
+Load the built `dist/` (or a `npm run zip` artifact) via your browser's
+extension developer page.
+
+## How it works (30-second version)
+
+1. A **background service worker** schedules checks using `browser.alarms` (or on browser
+   startup), based on a user-chosen frequency.
+2. On each check it fetches free-game data — Epic via a **JSON API**, Steam via **HTML
+   scraping** — and diffs against what's already stored.
+3. For new free games it **opens a store tab** and injects a **content script** that clicks
+   through the claim/add-to-account flow.
+4. A **React popup** lets the user configure platforms + frequency and view the games list
+   and a claim counter.
+
+See [architecture.md](./architecture.md) for the full model and [feature_status.md](./feature_status.md)
+for what works, known issues, and roadmap.
+
+## Coding standards
+
+This repo has no local lint/format config. Standards come from the globally-installed ECC
+rules (`~/.claude/rules/ecc/typescript/*`) plus the repo's `CLAUDE.md`. Key points:
+Conventional Commits, immutability, `@/entrypoints/...` path alias, `browser` namespace from
+`wxt/browser`, no `console.log` in production. See [tech_stack.md](./tech_stack.md#conventions).

--- a/docs/tech_stack.md
+++ b/docs/tech_stack.md
@@ -1,0 +1,52 @@
+# Tech Stack
+
+> Consolidated ECC doc. Covers technology stack, build/tooling, and coding standards.
+
+## Stack
+
+| Layer | Choice | Version | Notes |
+|-------|--------|---------|-------|
+| Language | TypeScript | ^5.8.3 | `strict` inherited from WXT's generated tsconfig. **Needs Verification** of exact flags. |
+| Extension framework | WXT | ^0.20.x | Web Extension Toolkit — entrypoint conventions, `browser` polyfill, storage, MV3 build. |
+| UI | React | ^19.1.0 | Popup only, via `@wxt-dev/module-react`. |
+| HTML parsing | node-html-parser | ^7.0.1 | Server-side Steam HTML scraping in the background worker. |
+| Build / dev | WXT CLI (`wxt`) | | `dev`, `build`, `zip`, per-browser (`-b firefox`). |
+| Package manager | npm (README) | | ⚠️ Both `package-lock.json` **and** `pnpm-lock.yaml` are committed — see tech debt. |
+
+## Build & tooling
+
+- **Verification gates (all green):** `npm run compile` (`tsc --noEmit`, **0 errors**), `npm test` (Vitest), and `npm run build` (`wxt build`).
+- **Tests:** Vitest via WXT's `WxtVitest` plugin (mocks `#imports`/`browser`/`storage`). Suites live beside sources as `*.test.ts`; DOM suites use `jsdom`, storage suites pin `// @vitest-environment node`.
+- **Build:** `npm run build` (Chrome) / `build:firefox`. Output → `wxt-dev-wxt/dist/`.
+- **Package:** `npm run zip` / `zip:firefox` for store submission.
+- **No linter, no formatter, no test runner** are configured.
+- **Targets:** Chrome (MV3) and Firefox (`browser_specific_settings.gecko`, min v109).
+
+## Repository layout
+
+```
+epic-free-games-claim/          # git root — README, imgs/, stub package.json, CLAUDE.md, docs/
+└── wxt-dev-wxt/                # ← the actual project
+    ├── wxt.config.ts           # manifest, permissions, browser targets
+    ├── tsconfig.json           # extends .wxt/tsconfig.json; @/* → project root
+    └── entrypoints/
+        ├── background.ts       # service worker (orchestrator)
+        ├── epic.content.ts     # content script (Epic)
+        ├── steam.content.ts    # content script (Steam)
+        ├── popup/              # React popup (App, main, html/css)
+        ├── components/         # React components
+        ├── hooks/useStorage.ts # storage abstraction
+        ├── utils/              # helpers, oncePerPageRun
+        ├── types/              # shared TS models
+        └── enums/              # ClaimFrequency, Platforms, StorageValues, ActiveTabs
+```
+
+## Conventions
+
+- **Imports:** absolute via `@/entrypoints/...` (alias `@` → `wxt-dev-wxt/`). Note: imports
+  include the `.ts` extension (`allowImportingTsExtensions`).
+- **Browser APIs:** import `browser` from `wxt/browser`; storage via `#imports`.
+- **Immutability:** prefer new objects/state over in-place mutation (per ECC coding-style).
+- **Commits:** Conventional Commits (`feat:`, `fix:`, `refactor:`, `docs:`, `chore:`).
+- **No `console.log`** in production code (one currently violates this — see tech debt).
+- Global ECC TypeScript rules apply: `~/.claude/rules/ecc/typescript/{coding-style,testing,security}.md`.

--- a/wxt-dev-wxt/entrypoints/background.ts
+++ b/wxt-dev-wxt/entrypoints/background.ts
@@ -1,10 +1,10 @@
 import {MessageRequest} from "@/entrypoints/types/messageRequest.ts";
-import {getStorageItem, getStorageItems, setStorageItem, setStorageItems} from "@/entrypoints/hooks/useStorage.ts";
+import {getStorageItem, getStorageItems, setStorageItem} from "@/entrypoints/hooks/useStorage.ts";
 import {FreeGame} from "@/entrypoints/types/freeGame.ts";
 import {Platforms} from "@/entrypoints/enums/platforms.ts";
 import {ClaimFrequency, ClaimFrequencyMinutes} from "@/entrypoints/enums/claimFrequency.ts";
 import {parse} from 'node-html-parser';
-import {browser} from "wxt/browser";
+import {browser, type Browser} from "wxt/browser";
 import {EpicElement, EpicKeyImage, EpicSearchResponse} from "@/entrypoints/types/epicGame.ts";
 
 const EPIC_API_URL = "https://store-site-backend-static-ipv4.ak.epicgames.com/freeGamesPromotions?locale=en-US";
@@ -16,17 +16,80 @@ const STEAM_GAMES_URL =
 const ALARM_NAME = "checkFreeGames";
 let isChecking = false;
 
-export default defineBackground({
+// --- Pure helpers (module-level and exported so they're unit-testable) ---
+
+export function areDatesDifferent(date1: string, date2: string): boolean {
+  return !!date1 && new Date(date1).toDateString() !== new Date(date2).toDateString();
+}
+
+export function didEnoughTimePass(lastOpened: string, requiredMinutes: number): boolean {
+  const lastDate = new Date(lastOpened);
+  const now = new Date();
+  const minutesElapsed = (now.getTime() - lastDate.getTime()) / (1000 * 60);
+  return minutesElapsed >= requiredMinutes;
+}
+
+// Force Epic claim pages into English (?lang=en-US) so the content script can match
+// confirmation buttons ("Add to library", etc.) by text regardless of the user's
+// account language. Non-Epic URLs (e.g. Steam) are returned unchanged.
+export function withEpicEnglishLocale(url: string): string {
+  try {
+    const parsed = new URL(url);
+    if (parsed.hostname.endsWith("epicgames.com")) {
+      parsed.searchParams.set("lang", "en-US");
+      return parsed.toString();
+    }
+  } catch {
+    // Not an absolute URL — leave it as-is.
+  }
+  return url;
+}
+
+export function formatEpicFreeGame(game: EpicElement, future: boolean): FreeGame {
+  const epicSlug =
+      game.productSlug ||
+      game.catalogNs?.mappings?.[0]?.pageSlug ||
+      game.offerMappings?.[0]?.pageSlug ||
+      "";
+
+  const isEpicBundle =
+      Array.isArray(game.categories) &&
+      game.categories.some((c) => c?.path === "bundles");
+
+  const slug = epicSlug;
+  const path = isEpicBundle ? "bundle" : "p";
+
+  const promo =
+      (future
+          ? game.promotions?.upcomingPromotionalOffers?.[0]?.promotionalOffers?.[0]
+          : game.promotions?.promotionalOffers?.[0]?.promotionalOffers?.[0]) ?? {};
+
+  return {
+    title: game.title ?? "",
+    platform: Platforms.Epic,
+    link: `https://www.epicgames.com/store/en-US/${path}/${slug}`,
+    img:
+        game.keyImages?.find((img: EpicKeyImage) => img.type === "Thumbnail")?.url ||
+        game.keyImages?.[0]?.url ||
+        "/icon/128.png",
+    description: game.description ?? "",
+    startDate: new Date(promo.startDate ?? 0).toISOString(),
+    endDate: new Date(promo.endDate ?? 0).toISOString(),
+    future,
+  };
+}
+
+const background = {
   async main() {
     browser.runtime.onStartup.addListener(() => this.handleStartup());
 
-    browser.runtime.onMessage.addListener((request: MessageRequest, sender: browser.runtime.MessageSender) =>
+    browser.runtime.onMessage.addListener((request: MessageRequest, sender: Browser.runtime.MessageSender) =>
         this.handleMessage(request, sender)
     );
 
-    browser.runtime.onInstalled.addListener((r: browser.runtime.InstalledDetails) => this.handleInstall(r));
+    browser.runtime.onInstalled.addListener((r: Browser.runtime.InstalledDetails) => this.handleInstall(r));
 
-    browser.alarms.onAlarm.addListener((alarm: browser.alarms.Alarm) => {
+    browser.alarms.onAlarm.addListener((alarm: Browser.alarms.Alarm) => {
       if (alarm.name === ALARM_NAME) {
         void this.handleAlarmTriggered();
       }
@@ -63,17 +126,17 @@ export default defineBackground({
       const today = new Date().toISOString();
       const lastOpened = await getStorageItem("lastOpened");
       if (!lastOpened) {
-        this.getFreeGamesAndSetOpenedFlag(today);
+        await this.getFreeGamesAndSetOpenedFlag(today);
         return;
       }
       if (frequency === ClaimFrequency.DAILY || frequency === ClaimFrequency.BROWSER_START) {
-        if (this.areDatesDifferent(lastOpened, today)) {
-          this.getFreeGamesAndSetOpenedFlag(today);
+        if (areDatesDifferent(lastOpened, today)) {
+          await this.getFreeGamesAndSetOpenedFlag(today);
         }
       } else {
         const requiredMinutes = ClaimFrequencyMinutes[frequency];
-          if (this.didEnoughTimePass(lastOpened, requiredMinutes)) {
-            this.getFreeGamesAndSetOpenedFlag(today);
+          if (didEnoughTimePass(lastOpened, requiredMinutes)) {
+            await this.getFreeGamesAndSetOpenedFlag(today);
           }
       }
     } finally {
@@ -82,20 +145,9 @@ export default defineBackground({
 
   },
 
-  areDatesDifferent(date1: string, date2: string): boolean {
-    return !!date1  && new Date(date1).toDateString() !== new Date(date2).toDateString();
-  },
-
-  getFreeGamesAndSetOpenedFlag(opened: string) {
-    this.getFreeGamesList();
-    void setStorageItem("lastOpened", opened);
-  },
-
-  didEnoughTimePass(lastOpened: string, requiredMinutes: number): boolean {
-    const lastDate = new Date(lastOpened);
-    const now = new Date();
-    const minutesElapsed = (now.getTime() - lastDate.getTime()) / (1000 * 60);
-    return minutesElapsed >= requiredMinutes;
+  async getFreeGamesAndSetOpenedFlag(opened: string) {
+    await this.getFreeGamesList();
+    await setStorageItem("lastOpened", opened);
   },
 
   async initializeAlarms() {
@@ -151,7 +203,7 @@ export default defineBackground({
     try {
       await this.getSteamGamesList(steamCheck);
     } catch (e) {
-      console.error("openTabAndSendActionToContent failed:", e);
+      console.error("getSteamGamesList failed:", e);
       if (steamCheck) await this.openTabAndSendActionToContent(STEAM_GAMES_URL, "getFreeGames");
     }
   },
@@ -159,7 +211,7 @@ export default defineBackground({
   async claimGames(games: FreeGame[]) {
     void this.setBadgeText(games.length.toString());
     for (const game of games) {
-      await this.openTabAndSendActionToContent(game.link, "claimGames");
+      await this.openTabAndSendActionToContent(withEpicEnglishLocale(game.link), "claimGames");
       await this.wait(10_000);
     }
   },
@@ -169,7 +221,7 @@ export default defineBackground({
       target: { tabId },
       world: "MAIN",
       args: [appId],
-      func: (appId: any) => {
+      func: (appId: number) => {
         const fn =
             (window as any).addToCart ||
             (window as any).AddToCart ||
@@ -207,10 +259,33 @@ export default defineBackground({
     const tab = await browser.tabs.create({ url });
     if (!tab || !tab.id) return;
     await this.waitForTabToLoad(tab.id);
-    await browser.tabs.sendMessage(tab.id, { target: "content", action });
+    await this.sendMessageWithRetry(tab.id, { target: "content", action });
   },
 
-  async handleMessage(request: MessageRequest, sender?: browser.runtime.MessageSender) {
+  // The content script registers its onMessage listener at document_idle, which
+  // can land slightly after tab status reaches "complete". Retry until the
+  // receiver is ready rather than losing the claim on the first
+  // "Could not establish connection" rejection.
+  async sendMessageWithRetry(
+      tabId: number,
+      message: { target: string; action: string },
+      maxRetries = 10,
+      delayMs = 300
+  ) {
+    for (let attempt = 0; attempt < maxRetries; attempt++) {
+      try {
+        return await browser.tabs.sendMessage(tabId, message);
+      } catch (e) {
+        if (attempt === maxRetries - 1) {
+          console.error(`sendMessageWithRetry: content script unreachable in tab ${tabId}`, e);
+          throw e;
+        }
+        await this.wait(delayMs);
+      }
+    }
+  },
+
+  async handleMessage(request: MessageRequest, sender?: Browser.runtime.MessageSender) {
     if (request.target !== "background") return;
 
     if (request.action === "claim") {
@@ -237,10 +312,6 @@ export default defineBackground({
     return new Promise((r) => setTimeout(r, ms));
   },
 
-  sendMessage(target: any, action: any) {
-    browser.runtime.sendMessage({ target, action });
-  },
-
   async waitForTabToLoad(tabId: number): Promise<void> {
     return new Promise((resolve, reject) => {
       async function checkTab() {
@@ -260,12 +331,10 @@ export default defineBackground({
     });
   },
 
-  handleInstall(r: browser.runtime.InstalledDetails) {
+  handleInstall(r: Browser.runtime.InstalledDetails) {
     if (r.reason === "update") {
       browser.action.setBadgeBackgroundColor({ color: "#50ca26" });
       void this.setBadgeText("New");
-    } else if (r.reason === "install") {
-
     }
   },
   async getEpicGamesList(shouldClaim: boolean = true) {
@@ -288,57 +357,23 @@ export default defineBackground({
         game.promotions?.upcomingPromotionalOffers?.[0]?.promotionalOffers?.[0]?.discountSetting?.discountPercentage === 0
     );
 
-    const currFreeGames: FreeGame[] = await getStorageItem("epicGames");
+    const currFreeGames: FreeGame[] = await getStorageItem("epicGames") || [];
     const newGames = freeGames.filter((game) =>
         !currFreeGames.some((g) => g?.title === game?.title)
     );
 
     if (newGames.length > 0) {
-      const formattedNewGames = newGames.map(g => this.formatEpicFreeGame(g, false));
+      const formattedNewGames = newGames.map(g => formatEpicFreeGame(g, false));
 
-      void setStorageItem("epicGames", formattedNewGames);
-      if (shouldClaim) this.claimGames(formattedNewGames);
+      await setStorageItem("epicGames", formattedNewGames);
+      if (shouldClaim) await this.claimGames(formattedNewGames);
     }
 
     if (futureFreeGames.length > 0) {
-      const formattedFutureGames = futureFreeGames.map(g => this.formatEpicFreeGame(g, true));
+      const formattedFutureGames = futureFreeGames.map(g => formatEpicFreeGame(g, true));
 
       await setStorageItem("futureGames", formattedFutureGames);
     }
-  },
-
-  formatEpicFreeGame(game: EpicElement, future: boolean): FreeGame {
-    const epicSlug =
-        game.productSlug ||
-        game.catalogNs?.mappings?.[0]?.pageSlug ||
-        game.offerMappings?.[0]?.pageSlug ||
-        "";
-
-    const isEpicBundle =
-        Array.isArray(game.categories) &&
-        game.categories.some((c) => c?.path === "bundles");
-
-    const slug = epicSlug;
-    const path = isEpicBundle ? "bundle" : "p";
-
-    const promo =
-        (future
-            ? game.promotions?.upcomingPromotionalOffers?.[0]?.promotionalOffers?.[0]
-            : game.promotions?.promotionalOffers?.[0]?.promotionalOffers?.[0]) ?? {};
-
-    return {
-      title: game.title ?? "",
-      platform: Platforms.Epic,
-      link: `https://www.epicgames.com/store/en-US/${path}/${slug}`,
-      img:
-          game.keyImages?.find((img: EpicKeyImage) => img.type === "Thumbnail")?.url ||
-          game.keyImages?.[0]?.url ||
-          "/icon/128.png",
-      description: game.description ?? "",
-      startDate: new Date(promo.startDate ?? 0).toISOString(),
-      endDate: new Date(promo.endDate ?? 0).toISOString(),
-      future,
-    };
   },
 
   async getSteamGamesList(shouldClaim: boolean = true) {
@@ -384,7 +419,7 @@ export default defineBackground({
     );
     if (newGames.length === 0) return;
 
-    if (shouldClaim) this.claimGames(newGames);
+    if (shouldClaim) await this.claimGames(newGames);
     await setStorageItem('steamGames', newGames);
   },
 
@@ -397,4 +432,6 @@ export default defineBackground({
   async setBadgeText(text: string) {
     await browser.action.setBadgeText({ text });
   }
-});
+};
+
+export default defineBackground(background);

--- a/wxt-dev-wxt/entrypoints/enums/claimFrequency.test.ts
+++ b/wxt-dev-wxt/entrypoints/enums/claimFrequency.test.ts
@@ -1,0 +1,33 @@
+import { describe, it, expect } from 'vitest';
+import {
+  ClaimFrequency,
+  ClaimFrequencyLabels,
+  ClaimFrequencyMinutes,
+} from './claimFrequency';
+
+describe('ClaimFrequency maps', () => {
+  it('defines a minutes interval for every frequency', () => {
+    for (const freq of Object.values(ClaimFrequency)) {
+      expect(ClaimFrequencyMinutes[freq]).toBeTypeOf('number');
+    }
+  });
+
+  it('defines a human label for every frequency', () => {
+    for (const freq of Object.values(ClaimFrequency)) {
+      expect(ClaimFrequencyLabels[freq]).toBeTruthy();
+    }
+  });
+
+  it('uses the expected alarm intervals', () => {
+    expect(ClaimFrequencyMinutes[ClaimFrequency.HOURLY]).toBe(60);
+    expect(ClaimFrequencyMinutes[ClaimFrequency.EVERY_6_HOURS]).toBe(360);
+    expect(ClaimFrequencyMinutes[ClaimFrequency.EVERY_12_HOURS]).toBe(720);
+    expect(ClaimFrequencyMinutes[ClaimFrequency.DAILY]).toBe(1440);
+  });
+
+  // BROWSER_START is handled via runtime.onStartup, not alarms, so its
+  // interval is intentionally 0 (never scheduled as a periodic alarm).
+  it('marks BROWSER_START with a zero interval', () => {
+    expect(ClaimFrequencyMinutes[ClaimFrequency.BROWSER_START]).toBe(0);
+  });
+});

--- a/wxt-dev-wxt/entrypoints/epic.content.ts
+++ b/wxt-dev-wxt/entrypoints/epic.content.ts
@@ -13,7 +13,8 @@ import {
     incrementCounter,
     realClick,
     findButtonByText,
-    findDeviceNotSupportedContinue
+    findDeviceNotSupportedContinue,
+    findAgeGateContinue
 } from "@/entrypoints/utils/helpers.ts";
 import {defineContentScript} from "wxt/utils/define-content-script";
 
@@ -61,6 +62,7 @@ export default defineContentScript({
         async function claimCurrentFreeGame() {
             await waitForPageLoad();
             await wait(getRndInteger(100, 500));
+            await dismissAgeGate();
             await clickWhenVisible('[data-testid="purchase-cta-button"]');
             console.log('[claimer] Clicked "Get"; completing claim');
 
@@ -71,6 +73,25 @@ export default defineContentScript({
             } else {
                 console.warn('[claimer] Could not complete claim within timeout');
                 logClaimDiagnostics();
+            }
+        }
+
+        // Mature-content games open behind an age-gate modal that blocks the
+        // purchase flow. Click its (enabled) "Continue" button before starting
+        // the claim. No-op when the game has no gate, so it's safe to always run.
+        async function dismissAgeGate(timeoutMs = 2500): Promise<void> {
+            const deadline = Date.now() + timeoutMs;
+            while (Date.now() < deadline) {
+                const button = findAgeGateContinue(document);
+                // getClientRects() is a reliable visibility check that also works
+                // for the modal's position:fixed layout (offsetParent would be null).
+                if (button && button.getClientRects().length > 0) {
+                    console.log('[claimer] Dismissing age-gate modal');
+                    await wait(getRndInteger(200, 400));
+                    realClick(button);
+                    return;
+                }
+                await wait(250);
             }
         }
 

--- a/wxt-dev-wxt/entrypoints/epic.content.ts
+++ b/wxt-dev-wxt/entrypoints/epic.content.ts
@@ -1,36 +1,33 @@
-import {MessageRequest} from "@/entrypoints/types/messageRequest.ts";
 import {FreeGame} from "@/entrypoints/types/freeGame.ts";
 import { browser } from 'wxt/browser';
 import {setStorageItem} from "@/entrypoints/hooks/useStorage.ts";
 import { oncePerPageRun } from "@/entrypoints/utils/oncePerPageRun";
 import {Platforms} from "@/entrypoints/enums/platforms.ts";
 import {FreeGamesResponse} from "@/entrypoints/types/freeGamesResponse.ts";
+import {onClaimMessage} from "@/entrypoints/utils/contentMessaging.ts";
 import {
     getRndInteger,
     wait,
-    clickWhenVisibleIframe,
     clickWhenVisible,
     waitForPageLoad,
-    incrementCounter
+    incrementCounter,
+    realClick,
+    findButtonByText,
+    findDeviceNotSupportedContinue
 } from "@/entrypoints/utils/helpers.ts";
 import {defineContentScript} from "wxt/utils/define-content-script";
 
 export default defineContentScript({
-    matches: ['https://store.epicgames.com/*'],
+    // Must cover both hosts Epic uses for product pages: the store homepage/scrape
+    // path (store.epicgames.com) AND the canonical product links that the API-based
+    // claim opens (www.epicgames.com/store/...). Missing the www host meant the
+    // content script was never injected on claim pages → "Receiving end does not exist".
+    matches: ['https://store.epicgames.com/*', 'https://www.epicgames.com/store/*'],
     main(_: any) {
         if (!oncePerPageRun('_myEpicContentScriptInjected')) {
             return;
         }
-        browser.runtime.onMessage.addListener((request: MessageRequest) => handleMessage(request));
-
-        function handleMessage(request: MessageRequest) {
-            if (request.target !== 'content') return;
-            if (request.action === 'getFreeGames') {
-                void getFreeGamesList();
-            } else if (request.action === "claimGames") {
-                void claimCurrentFreeGame();
-            }
-        }
+        onClaimMessage({ getFreeGames: getFreeGamesList, claimGames: claimCurrentFreeGame });
 
         async function getFreeGamesList() {
             await waitForPageLoad();
@@ -65,28 +62,152 @@ export default defineContentScript({
             await waitForPageLoad();
             await wait(getRndInteger(100, 500));
             await clickWhenVisible('[data-testid="purchase-cta-button"]');
-            await wait(getRndInteger(100, 500));
-            await tryClickDeviceNotSupportedContinue();
-            await clickWhenVisibleIframe('#webPurchaseContainer iframe', 'button.payment-btn.payment-order-confirm__btn');
-            await wait(getRndInteger(100, 500));
-            await clickWhenVisibleIframe('#webPurchaseContainer iframe', 'button.payment-confirm__btn.payment-btn--primary');
-            await incrementCounter();
+            console.log('[claimer] Clicked "Get"; completing claim');
+
+            const claimed = await completePurchase(40_000);
+            if (claimed) {
+                await incrementCounter();
+                console.log('[claimer] Claim completed');
+            } else {
+                console.warn('[claimer] Could not complete claim within timeout');
+                logClaimDiagnostics();
+            }
         }
 
-        async function tryClickDeviceNotSupportedContinue() {
-            const modalCtaButtons = document.querySelectorAll(
-                'div.css-16r1tk9 div.css-15w5v2y-CTA button[type="button"]'
-            );
-            const continueButton = modalCtaButtons.length > 1
-                ? (modalCtaButtons[modalCtaButtons.length - 1] as HTMLButtonElement)
-                : null;
-
-            if (!continueButton || continueButton.disabled) {
-                return;
+        // The purchase flow can render in the top document OR inside the (same-origin)
+        // #webPurchaseContainer iframe, so callers search both.
+        function getPurchaseIframeDoc(): Document | null {
+            const iframe = document.querySelector<HTMLIFrameElement>('#webPurchaseContainer iframe');
+            if (!iframe) return null;
+            try {
+                return iframe.contentDocument || iframe.contentWindow?.document || null;
+            } catch {
+                return null; // cross-origin — unreachable from here
             }
+        }
 
-            continueButton.click();
-            await wait(getRndInteger(150, 350));
+        function getSearchRoots(): Document[] {
+            const iframeDoc = getPurchaseIframeDoc();
+            return iframeDoc ? [iframeDoc, document] : [document];
+        }
+
+        // Drive the free-game claim to completion after "Get" is clicked by
+        // resolving whatever modal is in front of us each pass, until the
+        // order-confirmation screen renders. Epic shows a variable chain of
+        // blocking dialogs; the flow is NOT done just because we clicked the
+        // confirmation button:
+        //  - "Device not supported": platform-restriction modal → "Continue"
+        //  - "Add to library" / "Place Order": the free-purchase confirmation
+        //  - "I accept": the EU "Right of Withdrawal" consent shown AFTER the
+        //    confirmation for accounts in the EU (e.g. AT/DE). Without it the
+        //    order never completes and the flow hangs.
+        // All matched by text since Epic's hashed classes churn; locale is
+        // forced to en-US upstream so these English labels always apply.
+        async function completePurchase(timeoutMs: number): Promise<boolean> {
+            // Checked in priority order so a newly-shown blocking consent
+            // ("I accept") wins over re-clicking an already-handled button.
+            const CONFIRM_LABELS = ['i accept', 'add to library', 'place order'];
+            // Order-confirmation screen strings — the only reliable "done" signal.
+            const SUCCESS_RE = /thanks for your order|it['’]s all yours|has been added to your library/i;
+            const deadline = Date.now() + timeoutMs;
+            // Each confirmation/consent label is clicked at most once: Epic keeps
+            // the button in the DOM through the modal transition, so re-clicking
+            // it mid-transition cancels the purchase and wedges the flow. One
+            // click + a generous wait is what actually advances it.
+            const clickedLabels = new Set<string>();
+
+            while (Date.now() < deadline) {
+                const roots = getSearchRoots();
+
+                // Done once the confirmation screen renders in any reachable frame.
+                if (roots.some((root) => SUCCESS_RE.test(getRenderedText(root)))) {
+                    return true;
+                }
+
+                // Device-not-supported takes precedence; safe to re-dismiss since
+                // its Continue button vanishes once clicked.
+                const dismiss = findDeviceNotSupported(roots);
+                if (dismiss) {
+                    console.log('[claimer] Dismissing "Device not supported" modal');
+                    await wait(getRndInteger(200, 400)); // let the modal settle before clicking
+                    realClick(dismiss);
+                    await wait(getRndInteger(300, 600));
+                    continue;
+                }
+
+                // Confirmation/consent: only try labels we haven't already clicked.
+                const pending = CONFIRM_LABELS.filter((label) => !clickedLabels.has(label));
+                const confirm = findConfirmButton(roots, pending);
+                if (confirm) {
+                    const label = (confirm.textContent ?? '').trim().toLowerCase();
+                    clickedLabels.add(label);
+                    console.log(`[claimer] Clicking: "${confirm.textContent?.trim()}"`);
+                    await wait(getRndInteger(200, 400)); // let the modal settle before clicking
+                    realClick(confirm);
+                    await wait(getRndInteger(800, 1200)); // let the modal transition finish before re-scanning
+                    continue;
+                }
+
+                await wait(250);
+            }
+            return false;
+        }
+
+        // Use innerText, NOT textContent: the store page embeds a large
+        // localization JSON dictionary inside a <script> tag that contains the
+        // confirmation strings ("Thanks for your order", etc.) verbatim, so
+        // textContent would match SUCCESS_RE before anything is claimed.
+        // innerText excludes <script>/<style> and returns only rendered text.
+        function getRenderedText(doc: Document): string {
+            return doc.body?.innerText ?? '';
+        }
+
+        function findDeviceNotSupported(roots: Document[]): HTMLButtonElement | null {
+            for (const root of roots) {
+                const button = findDeviceNotSupportedContinue(root);
+                if (button && !button.disabled) return button;
+            }
+            return null;
+        }
+
+        function findConfirmButton(roots: Document[], labels: string[]): HTMLButtonElement | null {
+            for (const root of roots) {
+                for (const label of labels) {
+                    const button = findButtonByText(root, label);
+                    if (button && !button.disabled) return button;
+                }
+            }
+            return null;
+        }
+
+        // Diagnostic: dump the frame/iframe/modal picture so we can see WHERE the
+        // modal actually lives when the watcher can't reach it (e.g. a cross-origin
+        // purchase iframe our content script can't read or inject into).
+        function logClaimDiagnostics() {
+            const iframes: Array<Record<string, unknown>> = [];
+            document.querySelectorAll('iframe').forEach((f) => {
+                let access = 'null (likely cross-origin)';
+                let innerDialogs = -1;
+                let innerHasText = false;
+                try {
+                    const d = f.contentDocument || f.contentWindow?.document;
+                    if (d) {
+                        access = 'same-origin';
+                        innerDialogs = d.querySelectorAll('[role="dialog"]').length;
+                        innerHasText = /device not supported|not compatible/i.test(d.body?.innerText ?? '');
+                    }
+                } catch {
+                    access = 'cross-origin (blocked)';
+                }
+                iframes.push({ id: f.id, src: f.src, access, innerDialogs, innerHasText });
+            });
+            console.log('[claimer][diag]', JSON.stringify({
+                isTopFrame: window.top === window,
+                href: location.href,
+                dialogsInThisDoc: document.querySelectorAll('[role="dialog"]').length,
+                thisDocHasNotSupportedText: /device not supported|not compatible/i.test(document.body?.innerText ?? ''),
+                iframes,
+            }, null, 2));
         }
     },
 });

--- a/wxt-dev-wxt/entrypoints/hooks/useStorage.test.ts
+++ b/wxt-dev-wxt/entrypoints/hooks/useStorage.test.ts
@@ -1,0 +1,76 @@
+// @vitest-environment node
+// Storage helpers need no DOM. Running under node avoids the esbuild/jsdom
+// TextEncoder invariant clash that WXT's `#imports` transform triggers in jsdom.
+import { describe, it, expect, beforeEach } from 'vitest';
+import { fakeBrowser } from 'wxt/testing';
+import {
+  getStorageItem,
+  setStorageItem,
+  getStorageItems,
+  setStorageItems,
+  mergeIntoStorageItem,
+} from './useStorage';
+
+describe('useStorage helpers', () => {
+  beforeEach(() => {
+    // Reset the in-memory extension storage between tests.
+    fakeBrowser.reset();
+  });
+
+  describe('getStorageItem', () => {
+    // Regression anchor for the background.ts bug: a missing key returns null,
+    // so callers MUST guard (`... || []`) before calling array methods on it.
+    it('returns null for a key that was never set', async () => {
+      expect(await getStorageItem('epicGames')).toBeNull();
+    });
+
+    it('round-trips a value through setStorageItem', async () => {
+      await setStorageItem('counter', 3);
+      expect(await getStorageItem<number>('counter')).toBe(3);
+    });
+
+    it('stores and returns arrays intact', async () => {
+      const games = [{ title: 'A' }, { title: 'B' }];
+      await setStorageItem('steamGames', games);
+      expect(await getStorageItem('steamGames')).toEqual(games);
+    });
+  });
+
+  describe('getStorageItems / setStorageItems', () => {
+    it('writes and reads multiple keys by short name', async () => {
+      await setStorageItems({ active: true, epicCheck: false });
+      const result = await getStorageItems(['active', 'epicCheck']);
+      expect(result).toEqual({ active: true, epicCheck: false });
+    });
+
+    it('returns null for keys that are unset', async () => {
+      const result = await getStorageItems(['active']);
+      expect(result.active).toBeNull();
+    });
+  });
+
+  describe('mergeIntoStorageItem', () => {
+    it('creates an array from a single value when nothing is stored', async () => {
+      await mergeIntoStorageItem('list', 'a');
+      expect(await getStorageItem('list')).toEqual(['a']);
+    });
+
+    it('appends to an existing array', async () => {
+      await setStorageItem('list', ['a']);
+      await mergeIntoStorageItem('list', ['b', 'c']);
+      expect(await getStorageItem('list')).toEqual(['a', 'b', 'c']);
+    });
+
+    it('increments an existing number (counter behaviour)', async () => {
+      await setStorageItem('counter', 5);
+      await mergeIntoStorageItem('counter', 2);
+      expect(await getStorageItem<number>('counter')).toBe(7);
+    });
+
+    it('concatenates onto an existing string', async () => {
+      await setStorageItem('note', 'ab');
+      await mergeIntoStorageItem('note', 'c');
+      expect(await getStorageItem('note')).toBe('abc');
+    });
+  });
+});

--- a/wxt-dev-wxt/entrypoints/hooks/useStorage.ts
+++ b/wxt-dev-wxt/entrypoints/hooks/useStorage.ts
@@ -3,8 +3,12 @@ import {StorageValues} from "@/entrypoints/enums/storageValues.ts"
 import { storage } from '#imports';
 import {StorageItem} from "@/entrypoints/types/storageItem.ts";
 
+// Matches WXT's branded storage-key type. StorageValues values are exactly
+// local/session/sync/managed, so the runtime string always satisfies this shape.
+type StorageItemKey = `local:${string}` | `session:${string}` | `sync:${string}` | `managed:${string}`;
+
 export function useStorage<T>(key: string, defaultValue: T, storageType: StorageValues = StorageValues.LOCAL) {
-    const storageKey = `${storageType}:${key}`;
+    const storageKey = `${storageType}:${key}` as StorageItemKey;
     const [value, setValue] = useState<T>(defaultValue);
     const [isInitialized, setIsInitialized] = useState(false);
 
@@ -24,26 +28,26 @@ export function useStorage<T>(key: string, defaultValue: T, storageType: Storage
     return [value, setValue] as const;
 }
 
-export async function getStorageItem(key: string, storageType: StorageValues = StorageValues.LOCAL) {
-    const storageKey = `${storageType}:${key}`;
-    return await storage.getItem(storageKey);
+export async function getStorageItem<T = any>(key: string, storageType: StorageValues = StorageValues.LOCAL): Promise<T | null> {
+    const storageKey = `${storageType}:${key}` as StorageItemKey;
+    return await storage.getItem<T>(storageKey);
 }
 
 export async function setStorageItem(key: string, value: any, storageType: StorageValues = StorageValues.LOCAL) {
-    const storageKey = `${storageType}:${key}`;
+    const storageKey = `${storageType}:${key}` as StorageItemKey;
     await storage.setItem(storageKey, value);
 }
 
 export async function setStorageItems(items: Record<string, any>, storageType: StorageValues = StorageValues.LOCAL) {
-    const storageItems: StorageItem[] = Object.entries(items).map(([key, value]) => ({
-        key: `${storageType}:${key}`,
+    const storageItems = Object.entries(items).map(([key, value]) => ({
+        key: `${storageType}:${key}` as StorageItemKey,
         value
     }));
     await storage.setItems(storageItems);
 }
 
 export async function getStorageItems(keys: string[], storageType: StorageValues = StorageValues.LOCAL) {
-    const storageKeys: string[] = keys.map((key: string) => `${storageType}:${key}`);
+    const storageKeys: StorageItemKey[] = keys.map((key: string) => `${storageType}:${key}` as StorageItemKey);
     const items = await storage.getItems(storageKeys);
     return items.reduce((acc: { [x: string]: any; }, item: StorageItem) => {
         const shortKey = item.key.split(":")[1];
@@ -61,7 +65,7 @@ export async function mergeIntoStorageItem<T>(
     newValue: T | T[],
     storageType: StorageValues = StorageValues.LOCAL
 ) {
-    const storageKey = `${storageType}:${key}`;
+    const storageKey = `${storageType}:${key}` as StorageItemKey;
     const existingValue = await storage.getItem(storageKey);
 
     let updatedValue: unknown;

--- a/wxt-dev-wxt/entrypoints/steam.content.ts
+++ b/wxt-dev-wxt/entrypoints/steam.content.ts
@@ -1,13 +1,14 @@
 import {oncePerPageRun} from "@/entrypoints/utils/oncePerPageRun.ts";
 import {browser} from "wxt/browser";
-import {MessageRequest} from "@/entrypoints/types/messageRequest.ts";
 import {FreeGame} from "@/entrypoints/types/freeGame.ts";
 import {Platforms} from "@/entrypoints/enums/platforms.ts";
 import {FreeGamesResponse} from "@/entrypoints/types/freeGamesResponse.ts";
 import {setStorageItem} from "@/entrypoints/hooks/useStorage.ts";
+import {onClaimMessage} from "@/entrypoints/utils/contentMessaging.ts";
 import {
     clickWhenVisible,
-    incrementCounter, waitForAllElements,
+    incrementCounter,
+    waitForAllElements,
     waitForElement,
     waitForPageLoad
 } from "@/entrypoints/utils/helpers.ts";
@@ -18,16 +19,7 @@ export default defineContentScript({
         if (!oncePerPageRun('_mySteamContentScriptInjected' as keyof Window)) {
             return;
         }
-        browser.runtime.onMessage.addListener((request: MessageRequest) => handleMessage(request));
-
-        function handleMessage(request: MessageRequest) {
-            if (request.target !== 'content') return;
-            if (request.action === 'getFreeGames') {
-                void getFreeGamesList();
-            } else if (request.action === "claimGames") {
-                void claimCurrentFreeGame();
-            }
-        }
+        onClaimMessage({ getFreeGames: getFreeGamesList, claimGames: claimCurrentFreeGame });
 
         async function getFreeGamesList() {
             await waitForPageLoad();
@@ -50,7 +42,6 @@ export default defineContentScript({
                 freeGames: gamesArr,
                 loggedIn: isLoggedIn
             };
-            console.log(freeGamesResponse);
             await browser.runtime.sendMessage({
                 target: 'background',
                 action: 'claimFreeGames',

--- a/wxt-dev-wxt/entrypoints/tests/background.test.ts
+++ b/wxt-dev-wxt/entrypoints/tests/background.test.ts
@@ -1,0 +1,84 @@
+// @vitest-environment node
+// Lives under entrypoints/tests/ (not entrypoints/ root) so WXT doesn't treat it
+// as a duplicate "background" entrypoint. Node env avoids the esbuild/jsdom clash
+// from importing background.ts (which pulls in `#imports`).
+import { describe, it, expect } from 'vitest';
+import { areDatesDifferent, didEnoughTimePass, formatEpicFreeGame, withEpicEnglishLocale } from '../background';
+import { Platforms } from '../enums/platforms';
+
+describe('areDatesDifferent', () => {
+  it('is true for different calendar days', () => {
+    expect(areDatesDifferent('2026-01-01T12:00:00Z', '2026-06-15T12:00:00Z')).toBe(true);
+  });
+
+  it('is false for the same instant', () => {
+    expect(areDatesDifferent('2026-01-01T12:00:00Z', '2026-01-01T12:00:00Z')).toBe(false);
+  });
+
+  it('is false when the first date is empty (never claimed)', () => {
+    expect(areDatesDifferent('', '2026-06-15T12:00:00Z')).toBe(false);
+  });
+});
+
+describe('didEnoughTimePass', () => {
+  it('is true when more than the required minutes elapsed', () => {
+    const twoHoursAgo = new Date(Date.now() - 120 * 60 * 1000).toISOString();
+    expect(didEnoughTimePass(twoHoursAgo, 60)).toBe(true);
+  });
+
+  it('is false when not enough time has passed', () => {
+    const fiveMinAgo = new Date(Date.now() - 5 * 60 * 1000).toISOString();
+    expect(didEnoughTimePass(fiveMinAgo, 60)).toBe(false);
+  });
+});
+
+describe('formatEpicFreeGame', () => {
+  it('maps an Epic API element to a FreeGame', () => {
+    const el = {
+      title: 'Test Game',
+      productSlug: 'test-game',
+      description: 'desc',
+      keyImages: [{ type: 'Thumbnail', url: 'https://img/thumb.jpg' }],
+      promotions: {
+        promotionalOffers: [
+          { promotionalOffers: [{ startDate: '2026-01-01T00:00:00Z', endDate: '2026-01-08T00:00:00Z' }] },
+        ],
+      },
+    } as any;
+
+    const game = formatEpicFreeGame(el, false);
+    expect(game.title).toBe('Test Game');
+    expect(game.platform).toBe(Platforms.Epic);
+    expect(game.link).toBe('https://www.epicgames.com/store/en-US/p/test-game');
+    expect(game.img).toBe('https://img/thumb.jpg');
+    expect(game.future).toBe(false);
+    expect(game.endDate).toBe('2026-01-08T00:00:00.000Z');
+  });
+
+  it('uses the /bundle/ path for bundle products', () => {
+    const el = { title: 'B', productSlug: 'b', categories: [{ path: 'bundles' }] } as any;
+    expect(formatEpicFreeGame(el, false).link).toContain('/bundle/');
+  });
+
+  it('falls back to the default icon when no image is present', () => {
+    const el = { title: 'X', productSlug: 'x' } as any;
+    expect(formatEpicFreeGame(el, false).img).toBe('/icon/128.png');
+  });
+});
+
+describe('withEpicEnglishLocale', () => {
+  it('forces lang=en-US on an epicgames.com URL with no lang', () => {
+    expect(withEpicEnglishLocale('https://www.epicgames.com/store/de/p/x'))
+      .toBe('https://www.epicgames.com/store/de/p/x?lang=en-US');
+  });
+
+  it('overrides a non-English lang param', () => {
+    expect(withEpicEnglishLocale('https://store.epicgames.com/p/x?lang=de'))
+      .toBe('https://store.epicgames.com/p/x?lang=en-US');
+  });
+
+  it('leaves non-Epic URLs unchanged', () => {
+    const steam = 'https://store.steampowered.com/app/1/';
+    expect(withEpicEnglishLocale(steam)).toBe(steam);
+  });
+});

--- a/wxt-dev-wxt/entrypoints/utils/contentMessaging.ts
+++ b/wxt-dev-wxt/entrypoints/utils/contentMessaging.ts
@@ -1,0 +1,19 @@
+import { browser } from "wxt/browser";
+import { MessageRequest } from "@/entrypoints/types/messageRequest.ts";
+
+// Both store content scripts (Epic, Steam) respond to the same two background
+// actions. Centralize the target/action routing here so each store script only
+// supplies its own scrape (`getFreeGames`) and claim (`claimGames`) logic.
+export function onClaimMessage(handlers: {
+    getFreeGames: () => void | Promise<void>;
+    claimGames: () => void | Promise<void>;
+}): void {
+    browser.runtime.onMessage.addListener((request: MessageRequest) => {
+        if (request.target !== "content") return;
+        if (request.action === "getFreeGames") {
+            void handlers.getFreeGames();
+        } else if (request.action === "claimGames") {
+            void handlers.claimGames();
+        }
+    });
+}

--- a/wxt-dev-wxt/entrypoints/utils/helpers.test.ts
+++ b/wxt-dev-wxt/entrypoints/utils/helpers.test.ts
@@ -1,0 +1,147 @@
+import { describe, it, expect, afterEach } from 'vitest';
+import { getRndInteger, isVisible, waitForPageLoad, findButtonByText, findDeviceNotSupportedContinue } from './helpers';
+
+describe('getRndInteger', () => {
+  it('returns a value within [min, max] inclusive', () => {
+    for (let i = 0; i < 200; i++) {
+      const n = getRndInteger(5, 10);
+      expect(n).toBeGreaterThanOrEqual(5);
+      expect(n).toBeLessThanOrEqual(10);
+    }
+  });
+
+  it('returns exactly the value when min === max', () => {
+    expect(getRndInteger(7, 7)).toBe(7);
+  });
+});
+
+describe('isVisible', () => {
+  it('is false when display is none', () => {
+    const el = document.createElement('div');
+    el.style.display = 'none';
+    expect(isVisible(el)).toBe(false);
+  });
+
+  it('is true for a plain visible element', () => {
+    const el = document.createElement('div');
+    expect(isVisible(el)).toBe(true);
+  });
+});
+
+describe('findButtonByText', () => {
+  // Trimmed-down copy of the real Epic "Device not supported" modal CTA row.
+  const CTA_HTML = `
+    <div class="css-15w5v2y-CTA">
+      <button type="button"><span><span>Cancel</span></span></button>
+      <button type="button"><span><span>Continue</span></span></button>
+    </div>`;
+
+  it('returns the Continue button, not Cancel, from the modal CTA row', () => {
+    const root = document.createElement('div');
+    root.innerHTML = CTA_HTML;
+    const btn = findButtonByText(root, 'Continue');
+    expect(btn).not.toBeNull();
+    expect(btn?.textContent?.trim()).toBe('Continue');
+  });
+
+  it('is case-insensitive and trims whitespace', () => {
+    const root = document.createElement('div');
+    root.innerHTML = '<button>  CONTINUE  </button>';
+    expect(findButtonByText(root, 'continue')).not.toBeNull();
+  });
+
+  it('returns null when no button matches', () => {
+    const root = document.createElement('div');
+    root.innerHTML = '<button>Close</button>';
+    expect(findButtonByText(root, 'Continue')).toBeNull();
+  });
+
+  // The free-game claim confirmation is an "Add to library" button (nested spans).
+  it('matches the "Add to library" confirmation button by text', () => {
+    const root = document.createElement('div');
+    root.innerHTML = '<button type="button"><span class="eds-button__label">Add to library</span></button>';
+    expect(findButtonByText(root, 'add to library')).not.toBeNull();
+  });
+
+  // EU accounts get a "Right of Withdrawal" modal after confirmation; its
+  // "I accept" button must be matched to finish the claim. It must NOT collide
+  // with a plain "Accept" (e.g. an EULA button) since matching is exact.
+  it('matches "I accept" exactly without matching "Accept"', () => {
+    const root = document.createElement('div');
+    root.innerHTML =
+      '<button type="button"><span class="eds-button__label">Cancel</span></button>' +
+      '<button type="button"><span class="eds-button__label">I accept</span></button>';
+    expect(findButtonByText(root, 'i accept')?.textContent?.trim()).toBe('I accept');
+
+    const eula = document.createElement('div');
+    eula.innerHTML = '<button><span>Accept</span></button>';
+    expect(findButtonByText(eula, 'i accept')).toBeNull();
+  });
+});
+
+describe('findDeviceNotSupportedContinue', () => {
+  // Reproduces the real page state: TWO role="dialog" elements present, and the
+  // device-not-supported one is NOT first. Earlier code used querySelector (first
+  // match only) and missed it — this guards against that regression.
+  const TWO_DIALOGS_HTML = `
+    <div role="dialog" aria-modal="true">
+      <h4><span>Cookie preferences</span></h4>
+      <div class="cta"><button type="button"><span>Accept</span></button></div>
+    </div>
+    <div role="dialog" aria-modal="true">
+      <h4><span>Device not supported</span></h4>
+      <span>This product is not compatible with your current device</span>
+      <div class="cta">
+        <button type="button"><span><span>Cancel</span></span></button>
+        <button type="button"><span><span>Continue</span></span></button>
+      </div>
+    </div>`;
+
+  it('finds Continue in the device-not-supported dialog even when it is not the first dialog', () => {
+    const root = document.createElement('div');
+    root.innerHTML = TWO_DIALOGS_HTML;
+    const btn = findDeviceNotSupportedContinue(root);
+    expect(btn).not.toBeNull();
+    expect(btn?.textContent?.trim()).toBe('Continue');
+  });
+
+  it('returns null when no device-not-supported dialog is present', () => {
+    const root = document.createElement('div');
+    root.innerHTML = '<div role="dialog"><button>Continue</button></div>';
+    expect(findDeviceNotSupportedContinue(root)).toBeNull();
+  });
+});
+
+describe('waitForPageLoad', () => {
+  const original = Object.getOwnPropertyDescriptor(Document.prototype, 'readyState');
+
+  afterEach(() => {
+    if (original) Object.defineProperty(document, 'readyState', original);
+  });
+
+  const stubReadyState = (value: DocumentReadyState) =>
+    Object.defineProperty(document, 'readyState', { configurable: true, get: () => value });
+
+  it('resolves immediately when the document is already ready', async () => {
+    stubReadyState('complete');
+    await expect(waitForPageLoad()).resolves.toBeUndefined();
+  });
+
+  // Regression guard for the `!isDocumentReady` bug: before the fix the guard
+  // tested a function reference (always truthy), so it never waited and resolved
+  // immediately even while the document was still loading.
+  it('waits for DOMContentLoaded when the document is still loading', async () => {
+    stubReadyState('loading');
+    let resolved = false;
+    const pending = waitForPageLoad().then(() => {
+      resolved = true;
+    });
+
+    await Promise.resolve();
+    expect(resolved).toBe(false);
+
+    document.dispatchEvent(new Event('DOMContentLoaded'));
+    await pending;
+    expect(resolved).toBe(true);
+  });
+});

--- a/wxt-dev-wxt/entrypoints/utils/helpers.test.ts
+++ b/wxt-dev-wxt/entrypoints/utils/helpers.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, afterEach } from 'vitest';
-import { getRndInteger, isVisible, waitForPageLoad, findButtonByText, findDeviceNotSupportedContinue } from './helpers';
+import { getRndInteger, isVisible, waitForPageLoad, findButtonByText, findDeviceNotSupportedContinue, findAgeGateContinue } from './helpers';
 
 describe('getRndInteger', () => {
   it('returns a value within [min, max] inclusive', () => {
@@ -109,6 +109,31 @@ describe('findDeviceNotSupportedContinue', () => {
     const root = document.createElement('div');
     root.innerHTML = '<div role="dialog"><button>Continue</button></div>';
     expect(findDeviceNotSupportedContinue(root)).toBeNull();
+  });
+});
+
+describe('findAgeGateContinue', () => {
+  // Real markup: the age-gate Continue button carries a stable id.
+  const AGE_GATE = (disabled = false) =>
+    `<div role="dialog"><button type="button" id="btn_age_continue"${disabled ? ' disabled' : ''}>` +
+    '<span><span>Continue</span></span></button></div>';
+
+  it('returns the enabled #btn_age_continue button (logged-in acknowledgment)', () => {
+    const root = document.createElement('div');
+    root.innerHTML = AGE_GATE(false);
+    expect(findAgeGateContinue(root)?.id).toBe('btn_age_continue');
+  });
+
+  it('returns null for the disabled date-of-birth variant', () => {
+    const root = document.createElement('div');
+    root.innerHTML = AGE_GATE(true);
+    expect(findAgeGateContinue(root)).toBeNull();
+  });
+
+  it('returns null when there is no age gate', () => {
+    const root = document.createElement('div');
+    root.innerHTML = '<button id="something-else">Continue</button>';
+    expect(findAgeGateContinue(root)).toBeNull();
   });
 });
 

--- a/wxt-dev-wxt/entrypoints/utils/helpers.ts
+++ b/wxt-dev-wxt/entrypoints/utils/helpers.ts
@@ -58,23 +58,30 @@ export function realClick(el: HTMLElement | null) {
     el.dispatchEvent(new MouseEvent('click', { bubbles: true, cancelable: true }));
 }
 
-export async function clickWhenVisibleIframe(iframeSelector: string, buttonSelector: string) {
-    const iframe = await waitForElement(document, iframeSelector) as HTMLIFrameElement;
-    if (!iframe) return;
-    await new Promise<void>((resolve) => {
-        if (iframe.contentDocument?.readyState === 'complete') {
-            resolve();
-        } else {
-            iframe.addEventListener('load', () => resolve(), { once: true });
+// Find a <button> by its visible text (case-insensitive, trimmed). More robust
+// than positional or hashed-class selectors on Epic's frequently-churning DOM.
+export function findButtonByText(root: Document | HTMLElement, text: string): HTMLButtonElement | null {
+    const target = text.trim().toLowerCase();
+    const buttons = Array.from(root.querySelectorAll<HTMLButtonElement>('button'));
+    return buttons.find((btn) => (btn.textContent ?? '').trim().toLowerCase() === target) ?? null;
+}
+
+// Epic's page can have MULTIPLE role="dialog" elements at once, so we must scan
+// them all (not just the first) to find the "Device not supported" modal — matched
+// by its text — and return its "Continue" button.
+export function findDeviceNotSupportedContinue(root: Document | HTMLElement): HTMLButtonElement | null {
+    const dialogs = Array.from(root.querySelectorAll<HTMLElement>('[role="dialog"]'));
+    for (const dialog of dialogs) {
+        if (/not\s+(supported|compatible)/i.test(dialog.textContent ?? '')) {
+            const button = findButtonByText(dialog, 'Continue');
+            if (button) return button;
         }
-    });
-    await wait(2000);
-    const iframeDoc = iframe?.contentDocument || iframe?.contentWindow?.document;
-    await clickWhenVisible(buttonSelector, iframeDoc);
+    }
+    return null;
 }
 
 export async function waitForPageLoad() {
-    if (!isDocumentReady) {
+    if (!isDocumentReady()) {
         await new Promise<void>(resolve => {
             document.addEventListener('DOMContentLoaded', () => resolve(), {once: true});
         });

--- a/wxt-dev-wxt/entrypoints/utils/helpers.ts
+++ b/wxt-dev-wxt/entrypoints/utils/helpers.ts
@@ -80,6 +80,16 @@ export function findDeviceNotSupportedContinue(root: Document | HTMLElement): HT
     return null;
 }
 
+// Mature-content games open with an age-gate modal exposing a stable
+// #btn_age_continue "Continue" button. Return it only when present AND enabled
+// — logged-in, age-verified accounts get a plain acknowledgment (enabled),
+// while anonymous/unverified users get a date-of-birth variant that keeps the
+// button disabled until a birthday is entered (which we can't auto-fill).
+export function findAgeGateContinue(root: Document | HTMLElement): HTMLButtonElement | null {
+    const button = root.querySelector<HTMLButtonElement>('#btn_age_continue');
+    return button && !button.disabled ? button : null;
+}
+
 export async function waitForPageLoad() {
     if (!isDocumentReady()) {
         await new Promise<void>(resolve => {

--- a/wxt-dev-wxt/package-lock.json
+++ b/wxt-dev-wxt/package-lock.json
@@ -17,7 +17,9 @@
         "@types/react": "^19.1.2",
         "@types/react-dom": "^19.1.3",
         "@wxt-dev/module-react": "^1.1.3",
+        "jsdom": "^29.1.1",
         "typescript": "^5.8.3",
+        "vitest": "^4.1.10",
         "wxt": "^0.20.6"
       }
     },
@@ -121,6 +123,57 @@
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
       }
+    },
+    "node_modules/@asamuzakjp/css-color": {
+      "version": "5.1.11",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-5.1.11.tgz",
+      "integrity": "sha512-KVw6qIiCTUQhByfTd78h2yD1/00waTmm9uy/R7Ck/ctUyAPj+AEDLkQIdJW0T8+qGgj3j5bpNKK7Q3G+LedJWg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/generational-cache": "^1.0.1",
+        "@csstools/css-calc": "^3.2.0",
+        "@csstools/css-color-parser": "^4.1.0",
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/dom-selector": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/dom-selector/-/dom-selector-7.1.1.tgz",
+      "integrity": "sha512-67RZDnYRc8H/8MLDgQCDE//zoqVFwajkepHZgmXrbwybzXOEwOWGPYGmALYl9J2DOLfFPPs6kKCqmbzV895hTQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/generational-cache": "^1.0.1",
+        "@asamuzakjp/nwsapi": "^2.3.9",
+        "bidi-js": "^1.0.3",
+        "css-tree": "^3.2.1",
+        "is-potential-custom-element-name": "^1.0.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/generational-cache": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/generational-cache/-/generational-cache-1.0.1.tgz",
+      "integrity": "sha512-wajfB8KqzMCN2KGNFdLkReeHncd0AslUSrvHVvvYWuU8ghncRJoA50kT3zP9MVL0+9g4/67H+cdvBskj9THPzg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/nwsapi": {
+      "version": "2.3.9",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/nwsapi/-/nwsapi-2.3.9.tgz",
+      "integrity": "sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@babel/code-frame": {
       "version": "7.27.1",
@@ -392,6 +445,159 @@
       },
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@bramus/specificity": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/@bramus/specificity/-/specificity-2.4.2.tgz",
+      "integrity": "sha512-ctxtJ/eA+t+6q2++vj5j7FYX3nRu311q1wfYH3xjlLOsczhlhxAg2FWNUXhpGvAw3BWo1xBcvOV6/YLc2r5FJw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "css-tree": "^3.0.0"
+      },
+      "bin": {
+        "specificity": "bin/cli.js"
+      }
+    },
+    "node_modules/@csstools/color-helpers": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-6.1.0.tgz",
+      "integrity": "sha512-064IFJdjTfUqnjpCVpMOdbr8FLQBhinbZj6yRv2An2E41O/pLEXqfFRWqGq/SxlE5PEUYTlvWsG2r8MswAVvkg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=20.19.0"
+      }
+    },
+    "node_modules/@csstools/css-calc": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-3.2.1.tgz",
+      "integrity": "sha512-DtdHlgXh5ZkA43cwBcAm+huzgJiwx3ZTWVjBs94kwz2xKqSimDA3lBgCjphYgwgVUMWatSM0pDd8TILB1yrVVg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-color-parser": {
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-4.1.9.tgz",
+      "integrity": "sha512-paQcIaOO53Rk5+YrBaBjm/SgrV4INImjo2BT1DtQRYr+XeTRbeAYlS+jxXp9drqvKmtFnWRJKIalDLhZZDu42A==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/color-helpers": "^6.1.0",
+        "@csstools/css-calc": "^3.2.1"
+      },
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-parser-algorithms": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-4.0.0.tgz",
+      "integrity": "sha512-+B87qS7fIG3L5h3qwJ/IFbjoVoOe/bpOdh9hAjXbvx0o8ImEmUsGXN0inFOnk2ChCFgqkkGFQ+TpM5rbhkKe4w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-syntax-patches-for-csstree": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/@csstools/css-syntax-patches-for-csstree/-/css-syntax-patches-for-csstree-1.1.6.tgz",
+      "integrity": "sha512-TcJCWFbXLPpJYq6z7bfOyjWYJDiDg2/I4gyUC9pqPNqHFRIey0EB0q0L5cSnQDfWJg8Jd6VadakxdIez/3zkqQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "peerDependencies": {
+        "css-tree": "^3.2.1"
+      },
+      "peerDependenciesMeta": {
+        "css-tree": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@csstools/css-tokenizer": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-4.0.0.tgz",
+      "integrity": "sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
       }
     },
     "node_modules/@devicefarmer/adbkit": {
@@ -866,6 +1072,24 @@
         "node": ">=18"
       }
     },
+    "node_modules/@exodus/bytes": {
+      "version": "1.15.1",
+      "resolved": "https://registry.npmjs.org/@exodus/bytes/-/bytes-1.15.1.tgz",
+      "integrity": "sha512-S6mL0yNB/Abt9Ei4tq8gDhcczc4S3+vQ4ra7vxnAf+YHC02srtqxKKZghx2Dq6p0e66THKwR6r8N6P95wEty7Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "@noble/hashes": "^1.8.0 || ^2.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@noble/hashes": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@isaacs/balanced-match": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/@isaacs/balanced-match/-/balanced-match-4.0.1.tgz",
@@ -1300,6 +1524,13 @@
         "win32"
       ]
     },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
       "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.5.tgz",
@@ -1340,6 +1571,24 @@
       "dependencies": {
         "@babel/types": "^7.28.2"
       }
+    },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/estree": {
       "version": "1.0.8",
@@ -1429,6 +1678,119 @@
       },
       "peerDependencies": {
         "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0"
+      }
+    },
+    "node_modules/@vitest/expect": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.10.tgz",
+      "integrity": "sha512-YsCn+qAk1GWjQOWFEsEcL2gNQ0zmVmQu3T03qP6UyjhtmdtwtbuI+DASn/7iQB3HGTXkdBwGddzxPlmiql5vlA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.1.0",
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "4.1.10",
+        "@vitest/utils": "4.1.10",
+        "chai": "^6.2.2",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.10.tgz",
+      "integrity": "sha512-v0xaezt+DKEmKfaxg133ldzADrwLGd7Ze1MfQQTYfvs8OqZIwbxyxaYURivwV7sWy5fqn3rH5uOrSp07bp44Ow==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "4.1.10",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.21"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.10.tgz",
+      "integrity": "sha512-W1HsjSH4MXQ9YfmmhLAoIYf1HRfekQCGngeIgcei6MP5QQGWUe0gkopdZQaVCFO+JDJMrAJGwa5pRpNpvy4P8Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.10.tgz",
+      "integrity": "sha512-IKI6kpIH+LmpROplyLwBBaCfMgOZOMsygVa6BARD6ahA04VRuJSa6OaVG7kRvSEMD870Vd91rSSw0eegtWyLGg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "4.1.10",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.10.tgz",
+      "integrity": "sha512-xRkfOT1qpTAi/Ti4Y1LtfRc3kEuqxGw59eN2jN9pRWMtS/XDevekhcFSqvQqjUNGksfjMJu3Y+oJ+4Ypn2OaJw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.10",
+        "@vitest/utils": "4.1.10",
+        "magic-string": "^0.30.21",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.10.tgz",
+      "integrity": "sha512-PLf/Ugvoq5wO/b4rwYCR1h2PSIdXz7wnkQFMiUpLdtM7l6pqVFcQIBEHyT1+l+cj7mNwAfZHzqXqDyjvOuwbDw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.10.tgz",
+      "integrity": "sha512-fy9am/HWxbaGt/Sawrp90vt6Y6jQwf1RX77cz3uwoJwJVMli/e1IEwRPnMNJ7vKfPTwo0diXifkpPvwH9v7nGA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.10",
+        "convert-source-map": "^2.0.0",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
       }
     },
     "node_modules/@webext-core/fake-browser": {
@@ -1643,6 +2005,16 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/async": {
       "version": "3.2.6",
       "resolved": "https://registry.npmjs.org/async/-/async-3.2.6.tgz",
@@ -1710,6 +2082,16 @@
       "dev": true,
       "bin": {
         "baseline-browser-mapping": "dist/cli.js"
+      }
+    },
+    "node_modules/bidi-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/bidi-js/-/bidi-js-1.0.3.tgz",
+      "integrity": "sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "require-from-string": "^2.0.2"
       }
     },
     "node_modules/bl": {
@@ -1959,6 +2341,16 @@
           "url": "https://github.com/sponsors/ai"
         }
       ]
+    },
+    "node_modules/chai": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
+      "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/chalk": {
       "version": "5.6.2",
@@ -2521,6 +2913,20 @@
         "url": "https://github.com/sponsors/fb55"
       }
     },
+    "node_modules/css-tree": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-3.2.1.tgz",
+      "integrity": "sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mdn-data": "2.27.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0"
+      }
+    },
     "node_modules/css-what": {
       "version": "6.2.2",
       "resolved": "https://registry.npmjs.org/css-what/-/css-what-6.2.2.tgz",
@@ -2544,6 +2950,20 @@
       "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
       "dev": true
     },
+    "node_modules/data-urls": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-7.0.0.tgz",
+      "integrity": "sha512-23XHcCF+coGYevirZceTVD7NdJOqVn+49IHyxgszm+JIiHLoB2TkmPtsYkNWT1pvRSGkc35L6NHs0yHkN2SumA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-mimetype": "^5.0.0",
+        "whatwg-url": "^16.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
     "node_modules/debounce": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/debounce/-/debounce-1.2.1.tgz",
@@ -2566,6 +2986,13 @@
           "optional": true
         }
       }
+    },
+    "node_modules/decimal.js": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
+      "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/deep-extend": {
       "version": "0.6.0",
@@ -2932,6 +3359,16 @@
       "integrity": "sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA==",
       "dev": true
     },
+    "node_modules/expect-type": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.4.0.tgz",
+      "integrity": "sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
     "node_modules/exsolve": {
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/exsolve/-/exsolve-1.0.7.tgz",
@@ -3284,6 +3721,19 @@
       "integrity": "sha512-Yc+BQe8SvoXH1643Qez1zqLRmbA5rCL+sSmk6TVos0LWVfNIB7PGncdlId77WzLGSIB5KaWgTaNTs2lNVEI6VQ==",
       "dev": true
     },
+    "node_modules/html-encoding-sniffer": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-6.0.0.tgz",
+      "integrity": "sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@exodus/bytes": "^1.6.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
     "node_modules/html-escaper": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-3.0.3.tgz",
@@ -3619,6 +4069,57 @@
       "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
       "dev": true
     },
+    "node_modules/jsdom": {
+      "version": "29.1.1",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-29.1.1.tgz",
+      "integrity": "sha512-ECi4Fi2f7BdJtUKTflYRTiaMxIB0O6zfR1fX0GXpUrf6flp8QIYn1UT20YQqdSOfk2dfkCwS8LAFoJDEppNK5Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/css-color": "^5.1.11",
+        "@asamuzakjp/dom-selector": "^7.1.1",
+        "@bramus/specificity": "^2.4.2",
+        "@csstools/css-syntax-patches-for-csstree": "^1.1.3",
+        "@exodus/bytes": "^1.15.0",
+        "css-tree": "^3.2.1",
+        "data-urls": "^7.0.0",
+        "decimal.js": "^10.6.0",
+        "html-encoding-sniffer": "^6.0.0",
+        "is-potential-custom-element-name": "^1.0.1",
+        "lru-cache": "^11.3.5",
+        "parse5": "^8.0.1",
+        "saxes": "^6.0.0",
+        "symbol-tree": "^3.2.4",
+        "tough-cookie": "^6.0.1",
+        "undici": "^7.25.0",
+        "w3c-xmlserializer": "^5.0.0",
+        "webidl-conversions": "^8.0.1",
+        "whatwg-mimetype": "^5.0.0",
+        "whatwg-url": "^16.0.1",
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "canvas": "^3.0.0"
+      },
+      "peerDependenciesMeta": {
+        "canvas": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/jsdom/node_modules/lru-cache": {
+      "version": "11.5.2",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.2.tgz",
+      "integrity": "sha512-4pfM1Ff0x50o0tQwb5ucw/RzNyD0/YJME6IVcStalZuMWxdt3sR3huStTtxz4PUmvZfRguvDejasvQ2kifR11g==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
     "node_modules/jsesc": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.1.0.tgz",
@@ -3910,10 +4411,11 @@
       }
     },
     "node_modules/magic-string": {
-      "version": "0.30.19",
-      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.19.tgz",
-      "integrity": "sha512-2N21sPY9Ws53PZvsEpVtNuSW+ScYbQdp4b9qUaL+9QkHUrGFKo56Lg9Emg5s9V/qrtNBmiR01sYhUOwu3H+VOw==",
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.5.5"
       }
@@ -3949,6 +4451,13 @@
       "resolved": "https://registry.npmjs.org/marky/-/marky-1.3.0.tgz",
       "integrity": "sha512-ocnPZQLNpvbedwTy9kNrQEsknEfgvcLMvOtz3sFeWApDq1MXH1TqkCIx58xlpESsfwQOnuBO9beyQuNGzVvuhQ==",
       "dev": true
+    },
+    "node_modules/mdn-data": {
+      "version": "2.27.1",
+      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.27.1.tgz",
+      "integrity": "sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==",
+      "dev": true,
+      "license": "CC0-1.0"
     },
     "node_modules/merge2": {
       "version": "1.4.1",
@@ -4287,6 +4796,20 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/obug": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.3.tgz",
+      "integrity": "sha512-9miFgM2OFba7hB+pRgvtV84pYTBaoTHohvmIgiRt6dRIzbwEOIaNaP+dIlGs2fNFoB0SeISs0Jz5WFVRid6Xyg==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/sxzz",
+        "https://opencollective.com/debug"
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20.0"
+      }
+    },
     "node_modules/ofetch": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/ofetch/-/ofetch-1.4.1.tgz",
@@ -4442,6 +4965,19 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/parse5": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-8.0.1.tgz",
+      "integrity": "sha512-z1e/HMG90obSGeidlli3hj7cbocou0/wa5HacvI3ASx34PecNjNQeaHNo5WIZpWofN9kgkqV1q5YvXe3F0FoPw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "entities": "^8.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
     "node_modules/parse5-htmlparser2-tree-adapter": {
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/parse5-htmlparser2-tree-adapter/-/parse5-htmlparser2-tree-adapter-6.0.1.tgz",
@@ -4456,6 +4992,19 @@
       "resolved": "https://registry.npmjs.org/parse5/-/parse5-6.0.1.tgz",
       "integrity": "sha512-Ofn/CTFzRGTTxwpNEs9PP93gXShHcTq255nzRYSKe8AkVpZY7e1fpmTfOyoIvjP5HG7Z2ZM7VS9PPhQGW2pOpw==",
       "dev": true
+    },
+    "node_modules/parse5/node_modules/entities": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-8.0.0.tgz",
+      "integrity": "sha512-zwfzJecQ/Uej6tusMqwAqU/6KL2XaB2VZ2Jg54Je6ahNBGNH6Ek6g3jjNCF0fG9EWQKGZNddNjU5F1ZQn/sBnA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
     },
     "node_modules/pathe": {
       "version": "2.0.3",
@@ -4791,6 +5340,16 @@
         "once": "^1.3.1"
       }
     },
+    "node_modules/punycode": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+      "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/pupa": {
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/pupa/-/pupa-3.3.0.tgz",
@@ -4989,6 +5548,16 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/restore-cursor": {
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-5.1.0.tgz",
@@ -5118,6 +5687,19 @@
       "integrity": "sha512-+aWOz7yVScEGoKNd4PA10LZ8sk0A/z5+nXQG5giUO5rprX9jgYsTdov9qCchZiPIZezbZH+jRut8nPodFAX4Jg==",
       "dev": true
     },
+    "node_modules/saxes": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
+      "integrity": "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "xmlchars": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=v12.22.7"
+      }
+    },
     "node_modules/scheduler": {
       "version": "0.27.0",
       "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.27.0.tgz",
@@ -5173,6 +5755,13 @@
       "resolved": "https://registry.npmjs.org/shellwords/-/shellwords-0.1.1.tgz",
       "integrity": "sha512-vFwSUfQvqybiICwZY5+DAWIPLKsWO31Q91JSKl3UYv+K5c2QRPzn0qzec6QPu1Qc9eHYItiP3NdJqNVqetYAww==",
       "dev": true
+    },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/signal-exit": {
       "version": "4.1.0",
@@ -5285,6 +5874,20 @@
       "engines": {
         "node": ">= 10.x"
       }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.2.0.tgz",
+      "integrity": "sha512-oCUKSupKTHX53EyjDtuZQ64pjLJ6yYCtpmEw0goYxtjG9KpbRe8KAsl2tBUGU9DyMcJ0RwJ8GqJAFzMXcXW1Rw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/stdin-discarder": {
       "version": "0.2.2",
@@ -5399,6 +6002,13 @@
         "node": ">=8"
       }
     },
+    "node_modules/symbol-tree": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
+      "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/thenify": {
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/thenify/-/thenify-3.3.1.tgz",
@@ -5435,11 +6045,22 @@
       "integrity": "sha512-w89qg7PI8wAdvX60bMDP+bFoD5Dvhm9oLheFp5O4a2QF0cSBGsBX4qZmadPMvVqlLJBBci+WqGGOAPvcDeNSVg==",
       "dev": true
     },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/tinyexec": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.0.1.tgz",
-      "integrity": "sha512-5uC6DDlmeqiOwCPmK9jMSdOuZTh8bU39Ys6yidB+UTt5hfZUPGAypSgFRiEp+jbi9qH40BLDvy85jIU88wKSqw==",
-      "dev": true
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.2.4.tgz",
+      "integrity": "sha512-SHf/r48b7vOrjve9PxJo3MN5v5yuyjHvdUcrQffT3WXMUfnGmHDVbC4k3sHJaJTgZCwpUplIaAo5ANtMyp3YHg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/tinyglobby": {
       "version": "0.2.15",
@@ -5456,6 +6077,36 @@
       "funding": {
         "url": "https://github.com/sponsors/SuperchupuDev"
       }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.0.tgz",
+      "integrity": "sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tldts": {
+      "version": "7.4.8",
+      "resolved": "https://registry.npmjs.org/tldts/-/tldts-7.4.8.tgz",
+      "integrity": "sha512-htwgN/8KRB3z3vnC0BOETVh2m499g5GmyTK9Wq5JBLX3FNz6tSBveAd+fQhzy9hkjif8vy2jwDMR1sGhLtZl2A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tldts-core": "^7.4.8"
+      },
+      "bin": {
+        "tldts": "bin/cli.js"
+      }
+    },
+    "node_modules/tldts-core": {
+      "version": "7.4.8",
+      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.4.8.tgz",
+      "integrity": "sha512-c1P7u0EhACHj7lPy4MJm8iTFEU8+nB0LCtddH0fhP7noaVoXAqafMtOOeX+ulpuPBqnrRgRhw494RICT3mbhnw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/tmp": {
       "version": "0.2.5",
@@ -5476,6 +6127,32 @@
       },
       "engines": {
         "node": ">=8.0"
+      }
+    },
+    "node_modules/tough-cookie": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-6.0.2.tgz",
+      "integrity": "sha512-exgYmnmL/sJpR3upZfXG5PoatXQii55xAiXGXzY+sROLZ/Y+SLcp9PgJNI9Vz37HpQ74WvDcLT8eqm+kV3FzrA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "tldts": "^7.0.5"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/tr46": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-6.0.0.tgz",
+      "integrity": "sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/tslib": {
@@ -5526,6 +6203,16 @@
       "resolved": "https://registry.npmjs.org/uhyphen/-/uhyphen-0.2.0.tgz",
       "integrity": "sha512-qz3o9CHXmJJPGBdqzab7qAYuW8kQGKNEuoHFYrBwV6hWIMcpAmxDLXojcHfFr9US1Pe6zUswEIJIbLI610fuqA==",
       "dev": true
+    },
+    "node_modules/undici": {
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.28.0.tgz",
+      "integrity": "sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.1"
+      }
     },
     "node_modules/undici-types": {
       "version": "7.14.0",
@@ -5775,6 +6462,116 @@
         "url": "https://opencollective.com/vitest"
       }
     },
+    "node_modules/vitest": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.10.tgz",
+      "integrity": "sha512-R9jUTe5S4Qb0HCd4TNqpC7oGcrMssMRGXLW80ubjWsW9VH5GF8y1Y0SFLY9AbqSk6nt0PnOx4H4WNJYZ13GUPw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "4.1.10",
+        "@vitest/mocker": "4.1.10",
+        "@vitest/pretty-format": "4.1.10",
+        "@vitest/runner": "4.1.10",
+        "@vitest/snapshot": "4.1.10",
+        "@vitest/spy": "4.1.10",
+        "@vitest/utils": "4.1.10",
+        "es-module-lexer": "^2.0.0",
+        "expect-type": "^1.3.0",
+        "magic-string": "^0.30.21",
+        "obug": "^2.1.1",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.3",
+        "std-env": "^4.0.0-rc.1",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^1.0.2",
+        "tinyglobby": "^0.2.15",
+        "tinyrainbow": "^3.1.0",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@opentelemetry/api": "^1.9.0",
+        "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
+        "@vitest/browser-playwright": "4.1.10",
+        "@vitest/browser-preview": "4.1.10",
+        "@vitest/browser-webdriverio": "4.1.10",
+        "@vitest/coverage-istanbul": "4.1.10",
+        "@vitest/coverage-v8": "4.1.10",
+        "@vitest/ui": "4.1.10",
+        "happy-dom": "*",
+        "jsdom": "*",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser-playwright": {
+          "optional": true
+        },
+        "@vitest/browser-preview": {
+          "optional": true
+        },
+        "@vitest/browser-webdriverio": {
+          "optional": true
+        },
+        "@vitest/coverage-istanbul": {
+          "optional": true
+        },
+        "@vitest/coverage-v8": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        },
+        "vite": {
+          "optional": false
+        }
+      }
+    },
+    "node_modules/vitest/node_modules/es-module-lexer": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.3.1.tgz",
+      "integrity": "sha512-shc1dbU90Yl/xq1QrC7QRtfcwURZuVRfPhZbDoldJ1cn1gzDvBaBWlv0eFolj5+0znnPJz5TXLxsN77X/12KTA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/w3c-xmlserializer": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz",
+      "integrity": "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/watchpack": {
       "version": "2.4.4",
       "resolved": "https://registry.npmjs.org/watchpack/-/watchpack-2.4.4.tgz",
@@ -5829,11 +6626,46 @@
         "npm": ">=8.0.0"
       }
     },
+    "node_modules/webidl-conversions": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-8.0.1.tgz",
+      "integrity": "sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=20"
+      }
+    },
     "node_modules/webpack-virtual-modules": {
       "version": "0.6.2",
       "resolved": "https://registry.npmjs.org/webpack-virtual-modules/-/webpack-virtual-modules-0.6.2.tgz",
       "integrity": "sha512-66/V2i5hQanC51vBQKPH4aI8NMAcBW59FVBs+rC7eGHupMyfn34q7rZIE+ETlJ+XTevqfUhVVBgSUNSW2flEUQ==",
       "dev": true
+    },
+    "node_modules/whatwg-mimetype": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-5.0.0.tgz",
+      "integrity": "sha512-sXcNcHOC51uPGF0P/D4NVtrkjSU2fNsm9iog4ZvZJsL3rjoDAzXZhkm2MWt1y+PUdggKAYVoMAIYcs78wJ51Cw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/whatwg-url": {
+      "version": "16.0.1",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-16.0.1.tgz",
+      "integrity": "sha512-1to4zXBxmXHV3IiSSEInrreIlu02vUOvrhxJJH5vcxYTBDAx51cqZiKdyTxlecdKNSjj8EcxGBxNf6Vg+945gw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@exodus/bytes": "^1.11.0",
+        "tr46": "^6.0.0",
+        "webidl-conversions": "^8.0.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
     },
     "node_modules/when": {
       "version": "3.7.7",
@@ -5858,6 +6690,23 @@
       },
       "bin": {
         "which": "bin/which"
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/widest-line": {
@@ -5991,6 +6840,16 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/xml-name-validator": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
+      "integrity": "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/xml2js": {
       "version": "0.6.2",
       "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.6.2.tgz",
@@ -6012,6 +6871,13 @@
       "engines": {
         "node": ">=4.0"
       }
+    },
+    "node_modules/xmlchars": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
+      "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/y18n": {
       "version": "5.0.8",

--- a/wxt-dev-wxt/package-lock.json
+++ b/wxt-dev-wxt/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "free-game-claimer-for-steam-epic",
-  "version": "2.2.1",
+  "version": "2.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "free-game-claimer-for-steam-epic",
-      "version": "2.2.1",
+      "version": "2.3.0",
       "hasInstallScript": true,
       "dependencies": {
         "node-html-parser": "^7.0.1",
@@ -17,6 +17,7 @@
         "@types/react": "^19.1.2",
         "@types/react-dom": "^19.1.3",
         "@wxt-dev/module-react": "^1.1.3",
+        "happy-dom": "^20.10.6",
         "jsdom": "^29.1.1",
         "typescript": "^5.8.3",
         "vitest": "^4.1.10",
@@ -1650,6 +1651,23 @@
         "@types/react": "^19.2.0"
       }
     },
+    "node_modules/@types/whatwg-mimetype": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/whatwg-mimetype/-/whatwg-mimetype-3.0.2.tgz",
+      "integrity": "sha512-c2AKvDT8ToxLIOUlN51gTiHXflsfIFisS4pO7pDPoKouJCESkhZnEy623gwP9laCy5lnLDAw1vAzu2vM2YLOrA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/ws": {
+      "version": "8.18.1",
+      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.18.1.tgz",
+      "integrity": "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
     "node_modules/@types/yauzl": {
       "version": "2.10.3",
       "resolved": "https://registry.npmjs.org/@types/yauzl/-/yauzl-2.10.3.tgz",
@@ -2257,6 +2275,19 @@
       "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
       "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
       "dev": true
+    },
+    "node_modules/buffer-image-size": {
+      "version": "0.6.4",
+      "resolved": "https://registry.npmjs.org/buffer-image-size/-/buffer-image-size-0.6.4.tgz",
+      "integrity": "sha512-nEh+kZOPY1w+gcCMobZ6ETUp9WfibndnosbpwB1iJk/8Gt5ZF2bhS6+B6bPYz424KtwsR6Rflc3tCz1/ghX2dQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      },
+      "engines": {
+        "node": ">=4.0"
+      }
     },
     "node_modules/bundle-name": {
       "version": "4.1.0",
@@ -3688,6 +3719,48 @@
       "resolved": "https://registry.npmjs.org/growly/-/growly-1.3.0.tgz",
       "integrity": "sha512-+xGQY0YyAWCnqy7Cd++hc2JqMYzlm0dG30Jd0beaA64sROr8C4nt8Yc9V5Ro3avlSUDTN0ulqP/VBKi1/lLygw==",
       "dev": true
+    },
+    "node_modules/happy-dom": {
+      "version": "20.10.6",
+      "resolved": "https://registry.npmjs.org/happy-dom/-/happy-dom-20.10.6.tgz",
+      "integrity": "sha512-6QD0ilzDDt93tX44y8tbmZdAcdTRYDhUP+Asgi6pC8Pp5IA3cvaZGyoVN/EGtlq9ziT65iPuBBn3ASLr6hCgVw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": ">=20.0.0",
+        "@types/whatwg-mimetype": "^3.0.2",
+        "@types/ws": "^8.18.1",
+        "buffer-image-size": "^0.6.4",
+        "entities": "^7.0.1",
+        "whatwg-mimetype": "^3.0.0",
+        "ws": "^8.21.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/happy-dom/node_modules/entities": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-7.0.1.tgz",
+      "integrity": "sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/happy-dom/node_modules/whatwg-mimetype": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-3.0.0.tgz",
+      "integrity": "sha512-nt+N2dzIutVRxARx1nghPKGv1xHikU7HKdfafKkLNLindmPU/ch3U31NOCGGA/dmPcmb1VlofO0vnKAcsm0o/Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
     },
     "node_modules/has-flag": {
       "version": "4.0.0",
@@ -6752,6 +6825,28 @@
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
       "dev": true
+    },
+    "node_modules/ws": {
+      "version": "8.21.1",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.1.tgz",
+      "integrity": "sha512-+0NTnW77fFN/DjQi6k/Sq/Yvk4Sgajw7urW8V+asjXnRgDs9gyGkdb7EzgfhA4goXsRIZKE28fzIXBHEzhuiWw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
     },
     "node_modules/wsl-utils": {
       "version": "0.1.0",

--- a/wxt-dev-wxt/package-lock.json
+++ b/wxt-dev-wxt/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "free-game-claimer-for-steam-epic",
-  "version": "2.3.0",
+  "version": "2.4.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "free-game-claimer-for-steam-epic",
-      "version": "2.3.0",
+      "version": "2.4.0",
       "hasInstallScript": true,
       "dependencies": {
         "node-html-parser": "^7.0.1",

--- a/wxt-dev-wxt/package.json
+++ b/wxt-dev-wxt/package.json
@@ -12,6 +12,8 @@
     "zip": "wxt zip",
     "zip:firefox": "wxt zip -b firefox",
     "compile": "tsc --noEmit",
+    "test": "vitest run",
+    "test:watch": "vitest",
     "postinstall": "wxt prepare"
   },
   "dependencies": {
@@ -23,7 +25,10 @@
     "@types/react": "^19.1.2",
     "@types/react-dom": "^19.1.3",
     "@wxt-dev/module-react": "^1.1.3",
+    "happy-dom": "^20.10.6",
+    "jsdom": "^29.1.1",
     "typescript": "^5.8.3",
+    "vitest": "^4.1.10",
     "wxt": "^0.20.6"
   }
 }

--- a/wxt-dev-wxt/package.json
+++ b/wxt-dev-wxt/package.json
@@ -2,7 +2,7 @@
   "name": "free-game-claimer-for-steam-epic",
   "description": "script to claim free games on Epic Games Store",
   "private": false,
-  "version": "2.3.0",
+  "version": "2.4.0",
   "type": "module",
   "scripts": {
     "dev": "wxt",

--- a/wxt-dev-wxt/package.json
+++ b/wxt-dev-wxt/package.json
@@ -2,7 +2,7 @@
   "name": "free-game-claimer-for-steam-epic",
   "description": "script to claim free games on Epic Games Store",
   "private": false,
-  "version": "2.2.1",
+  "version": "2.3.0",
   "type": "module",
   "scripts": {
     "dev": "wxt",

--- a/wxt-dev-wxt/pnpm-lock.yaml
+++ b/wxt-dev-wxt/pnpm-lock.yaml
@@ -8,6 +8,9 @@ importers:
 
   .:
     dependencies:
+      node-html-parser:
+        specifier: ^7.0.1
+        version: 7.1.0
       react:
         specifier: ^19.1.0
         version: 19.1.0
@@ -24,9 +27,18 @@ importers:
       '@wxt-dev/module-react':
         specifier: ^1.1.3
         version: 1.1.3(vite@6.3.5(@types/node@24.0.7)(jiti@2.4.2))(wxt@0.20.7(@types/node@24.0.7)(jiti@2.4.2)(rollup@4.44.1))
+      happy-dom:
+        specifier: ^20.10.6
+        version: 20.10.6
+      jsdom:
+        specifier: ^29.1.1
+        version: 29.1.1
       typescript:
         specifier: ^5.8.3
         version: 5.8.3
+      vitest:
+        specifier: ^4.1.10
+        version: 4.1.10(@types/node@24.0.7)(happy-dom@20.10.6)(jsdom@29.1.1)(vite@6.3.5(@types/node@24.0.7)(jiti@2.4.2))
       wxt:
         specifier: ^0.20.6
         version: 0.20.7(@types/node@24.0.7)(jiti@2.4.2)(rollup@4.44.1)
@@ -49,6 +61,21 @@ packages:
   '@ampproject/remapping@2.3.0':
     resolution: {integrity: sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw==}
     engines: {node: '>=6.0.0'}
+
+  '@asamuzakjp/css-color@5.1.11':
+    resolution: {integrity: sha512-KVw6qIiCTUQhByfTd78h2yD1/00waTmm9uy/R7Ck/ctUyAPj+AEDLkQIdJW0T8+qGgj3j5bpNKK7Q3G+LedJWg==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
+
+  '@asamuzakjp/dom-selector@7.1.1':
+    resolution: {integrity: sha512-67RZDnYRc8H/8MLDgQCDE//zoqVFwajkepHZgmXrbwybzXOEwOWGPYGmALYl9J2DOLfFPPs6kKCqmbzV895hTQ==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
+
+  '@asamuzakjp/generational-cache@1.0.1':
+    resolution: {integrity: sha512-wajfB8KqzMCN2KGNFdLkReeHncd0AslUSrvHVvvYWuU8ghncRJoA50kT3zP9MVL0+9g4/67H+cdvBskj9THPzg==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
+
+  '@asamuzakjp/nwsapi@2.3.9':
+    resolution: {integrity: sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q==}
 
   '@babel/code-frame@7.27.1':
     resolution: {integrity: sha512-cjQ7ZlQ0Mv3b47hABuTevyTuYN4i+loJKGeV9flcCgIK37cCXRh+L1bd3iBHlynerhQ7BhCkn2BPbQUL+rGqFg==}
@@ -132,6 +159,46 @@ packages:
   '@babel/types@7.27.7':
     resolution: {integrity: sha512-8OLQgDScAOHXnAz2cV+RfzzNMipuLVBz2biuAJFMV9bfkNf393je3VM8CLkjQodW5+iWsSJdSgSWT6rsZoXHPw==}
     engines: {node: '>=6.9.0'}
+
+  '@bramus/specificity@2.4.2':
+    resolution: {integrity: sha512-ctxtJ/eA+t+6q2++vj5j7FYX3nRu311q1wfYH3xjlLOsczhlhxAg2FWNUXhpGvAw3BWo1xBcvOV6/YLc2r5FJw==}
+    hasBin: true
+
+  '@csstools/color-helpers@6.1.0':
+    resolution: {integrity: sha512-064IFJdjTfUqnjpCVpMOdbr8FLQBhinbZj6yRv2An2E41O/pLEXqfFRWqGq/SxlE5PEUYTlvWsG2r8MswAVvkg==}
+    engines: {node: '>=20.19.0'}
+
+  '@csstools/css-calc@3.2.1':
+    resolution: {integrity: sha512-DtdHlgXh5ZkA43cwBcAm+huzgJiwx3ZTWVjBs94kwz2xKqSimDA3lBgCjphYgwgVUMWatSM0pDd8TILB1yrVVg==}
+    engines: {node: '>=20.19.0'}
+    peerDependencies:
+      '@csstools/css-parser-algorithms': ^4.0.0
+      '@csstools/css-tokenizer': ^4.0.0
+
+  '@csstools/css-color-parser@4.1.9':
+    resolution: {integrity: sha512-paQcIaOO53Rk5+YrBaBjm/SgrV4INImjo2BT1DtQRYr+XeTRbeAYlS+jxXp9drqvKmtFnWRJKIalDLhZZDu42A==}
+    engines: {node: '>=20.19.0'}
+    peerDependencies:
+      '@csstools/css-parser-algorithms': ^4.0.0
+      '@csstools/css-tokenizer': ^4.0.0
+
+  '@csstools/css-parser-algorithms@4.0.0':
+    resolution: {integrity: sha512-+B87qS7fIG3L5h3qwJ/IFbjoVoOe/bpOdh9hAjXbvx0o8ImEmUsGXN0inFOnk2ChCFgqkkGFQ+TpM5rbhkKe4w==}
+    engines: {node: '>=20.19.0'}
+    peerDependencies:
+      '@csstools/css-tokenizer': ^4.0.0
+
+  '@csstools/css-syntax-patches-for-csstree@1.1.6':
+    resolution: {integrity: sha512-TcJCWFbXLPpJYq6z7bfOyjWYJDiDg2/I4gyUC9pqPNqHFRIey0EB0q0L5cSnQDfWJg8Jd6VadakxdIez/3zkqQ==}
+    peerDependencies:
+      css-tree: ^3.2.1
+    peerDependenciesMeta:
+      css-tree:
+        optional: true
+
+  '@csstools/css-tokenizer@4.0.0':
+    resolution: {integrity: sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA==}
+    engines: {node: '>=20.19.0'}
 
   '@devicefarmer/adbkit-logcat@2.1.3':
     resolution: {integrity: sha512-yeaGFjNBc/6+svbDeul1tNHtNChw6h8pSHAt5D+JsedUrMTN7tla7B15WLDyekxsuS2XlZHRxpuC6m92wiwCNw==}
@@ -296,6 +363,15 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@exodus/bytes@1.15.1':
+    resolution: {integrity: sha512-S6mL0yNB/Abt9Ei4tq8gDhcczc4S3+vQ4ra7vxnAf+YHC02srtqxKKZghx2Dq6p0e66THKwR6r8N6P95wEty7Q==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
+    peerDependencies:
+      '@noble/hashes': ^1.8.0 || ^2.0.0
+    peerDependenciesMeta:
+      '@noble/hashes':
+        optional: true
+
   '@isaacs/balanced-match@4.0.1':
     resolution: {integrity: sha512-yzMTt9lEb8Gv7zRioUilSglI0c0smZ9k5D65677DLWLtWJaXIS3CqcGyUFByYKlnUj6TkjLVs54fBl6+TiGQDQ==}
     engines: {node: 20 || >=22}
@@ -318,6 +394,9 @@ packages:
 
   '@jridgewell/sourcemap-codec@1.5.0':
     resolution: {integrity: sha512-gv3ZRaISU3fjPAgNsriBRqGWQL6quFx04YMPW/zD8XMLsU32mhCCbfbO6KZFLjvYpCZ8zyDEgqsgf+PwPaM7GQ==}
+
+  '@jridgewell/sourcemap-codec@1.5.5':
+    resolution: {integrity: sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==}
 
   '@jridgewell/trace-mapping@0.3.25':
     resolution: {integrity: sha512-vNk6aEwybGtawWmy/PzwnGDOjCkLWSD2wqvjGGAgOAwCGWySYXfYoxt00IJkTF+8Lb57DwOb3Aa0o9CApepiYQ==}
@@ -383,56 +462,67 @@ packages:
     resolution: {integrity: sha512-n0edDmSHlXFhrlmTK7XBuwKlG5MbS7yleS1cQ9nn4kIeW+dJH+ExqNgQ0RrFRew8Y+0V/x6C5IjsHrJmiHtkxQ==}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm-musleabihf@4.44.1':
     resolution: {integrity: sha512-8WVUPy3FtAsKSpyk21kV52HCxB+me6YkbkFHATzC2Yd3yuqHwy2lbFL4alJOLXKljoRw08Zk8/xEj89cLQ/4Nw==}
     cpu: [arm]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-arm64-gnu@4.44.1':
     resolution: {integrity: sha512-yuktAOaeOgorWDeFJggjuCkMGeITfqvPgkIXhDqsfKX8J3jGyxdDZgBV/2kj/2DyPaLiX6bPdjJDTu9RB8lUPQ==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm64-musl@4.44.1':
     resolution: {integrity: sha512-W+GBM4ifET1Plw8pdVaecwUgxmiH23CfAUj32u8knq0JPFyK4weRy6H7ooxYFD19YxBulL0Ktsflg5XS7+7u9g==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-loongarch64-gnu@4.44.1':
     resolution: {integrity: sha512-1zqnUEMWp9WrGVuVak6jWTl4fEtrVKfZY7CvcBmUUpxAJ7WcSowPSAWIKa/0o5mBL/Ij50SIf9tuirGx63Ovew==}
     cpu: [loong64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-powerpc64le-gnu@4.44.1':
     resolution: {integrity: sha512-Rl3JKaRu0LHIx7ExBAAnf0JcOQetQffaw34T8vLlg9b1IhzcBgaIdnvEbbsZq9uZp3uAH+JkHd20Nwn0h9zPjA==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-gnu@4.44.1':
     resolution: {integrity: sha512-j5akelU3snyL6K3N/iX7otLBIl347fGwmd95U5gS/7z6T4ftK288jKq3A5lcFKcx7wwzb5rgNvAg3ZbV4BqUSw==}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-musl@4.44.1':
     resolution: {integrity: sha512-ppn5llVGgrZw7yxbIm8TTvtj1EoPgYUAbfw0uDjIOzzoqlZlZrLJ/KuiE7uf5EpTpCTrNt1EdtzF0naMm0wGYg==}
     cpu: [riscv64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-s390x-gnu@4.44.1':
     resolution: {integrity: sha512-Hu6hEdix0oxtUma99jSP7xbvjkUM/ycke/AQQ4EC5g7jNRLLIwjcNwaUy95ZKBJJwg1ZowsclNnjYqzN4zwkAw==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-gnu@4.44.1':
     resolution: {integrity: sha512-EtnsrmZGomz9WxK1bR5079zee3+7a+AdFlghyd6VbAjgRJDbTANJ9dcPIPAi76uG05micpEL+gPGmAKYTschQw==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-musl@4.44.1':
     resolution: {integrity: sha512-iAS4p+J1az6Usn0f8xhgL4PaU878KEtutP4hqw52I4IO6AGoyOkHCxcc4bqufv1tQLdDWFx8lR9YlwxKuv3/3g==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-win32-arm64-msvc@4.44.1':
     resolution: {integrity: sha512-NtSJVKcXwcqozOl+FwI41OH3OApDyLk3kqTJgx8+gp6On9ZEt5mYhIsKNPGuaZr3p9T6NWPKGU/03Vw4CNU9qg==}
@@ -449,6 +539,9 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@standard-schema/spec@1.1.0':
+    resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
+
   '@types/babel__core@7.20.5':
     resolution: {integrity: sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA==}
 
@@ -460,6 +553,12 @@ packages:
 
   '@types/babel__traverse@7.20.7':
     resolution: {integrity: sha512-dkO5fhS7+/oos4ciWxyEyjWe48zmG6wbCheo/G2ZnHx4fs3EU6YC6UM8rk56gAjNJ9P3MTH2jo5jb92/K6wbng==}
+
+  '@types/chai@5.2.3':
+    resolution: {integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==}
+
+  '@types/deep-eql@4.0.2':
+    resolution: {integrity: sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==}
 
   '@types/estree@1.0.8':
     resolution: {integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==}
@@ -487,6 +586,12 @@ packages:
   '@types/react@19.1.8':
     resolution: {integrity: sha512-AwAfQ2Wa5bCx9WP8nZL2uMZWod7J7/JSplxbTmBQ5ms6QpqNYm672H0Vu9ZVKVngQ+ii4R/byguVEUZQyeg44g==}
 
+  '@types/whatwg-mimetype@3.0.2':
+    resolution: {integrity: sha512-c2AKvDT8ToxLIOUlN51gTiHXflsfIFisS4pO7pDPoKouJCESkhZnEy623gwP9laCy5lnLDAw1vAzu2vM2YLOrA==}
+
+  '@types/ws@8.18.1':
+    resolution: {integrity: sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==}
+
   '@types/yauzl@2.10.3':
     resolution: {integrity: sha512-oJoftv0LSuaDZE3Le4DbKX+KS9G36NzOeSap90UIK0yMA/NhKJhqlSGtNDORNRaIbQfzjXDrQa0ytJ6mNRGz/Q==}
 
@@ -495,6 +600,35 @@ packages:
     engines: {node: ^14.18.0 || >=16.0.0}
     peerDependencies:
       vite: ^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0-beta.0
+
+  '@vitest/expect@4.1.10':
+    resolution: {integrity: sha512-YsCn+qAk1GWjQOWFEsEcL2gNQ0zmVmQu3T03qP6UyjhtmdtwtbuI+DASn/7iQB3HGTXkdBwGddzxPlmiql5vlA==}
+
+  '@vitest/mocker@4.1.10':
+    resolution: {integrity: sha512-v0xaezt+DKEmKfaxg133ldzADrwLGd7Ze1MfQQTYfvs8OqZIwbxyxaYURivwV7sWy5fqn3rH5uOrSp07bp44Ow==}
+    peerDependencies:
+      msw: ^2.4.9
+      vite: ^6.0.0 || ^7.0.0 || ^8.0.0
+    peerDependenciesMeta:
+      msw:
+        optional: true
+      vite:
+        optional: true
+
+  '@vitest/pretty-format@4.1.10':
+    resolution: {integrity: sha512-W1HsjSH4MXQ9YfmmhLAoIYf1HRfekQCGngeIgcei6MP5QQGWUe0gkopdZQaVCFO+JDJMrAJGwa5pRpNpvy4P8Q==}
+
+  '@vitest/runner@4.1.10':
+    resolution: {integrity: sha512-IKI6kpIH+LmpROplyLwBBaCfMgOZOMsygVa6BARD6ahA04VRuJSa6OaVG7kRvSEMD870Vd91rSSw0eegtWyLGg==}
+
+  '@vitest/snapshot@4.1.10':
+    resolution: {integrity: sha512-xRkfOT1qpTAi/Ti4Y1LtfRc3kEuqxGw59eN2jN9pRWMtS/XDevekhcFSqvQqjUNGksfjMJu3Y+oJ+4Ypn2OaJw==}
+
+  '@vitest/spy@4.1.10':
+    resolution: {integrity: sha512-PLf/Ugvoq5wO/b4rwYCR1h2PSIdXz7wnkQFMiUpLdtM7l6pqVFcQIBEHyT1+l+cj7mNwAfZHzqXqDyjvOuwbDw==}
+
+  '@vitest/utils@4.1.10':
+    resolution: {integrity: sha512-fy9am/HWxbaGt/Sawrp90vt6Y6jQwf1RX77cz3uwoJwJVMli/e1IEwRPnMNJ7vKfPTwo0diXifkpPvwH9v7nGA==}
 
   '@webext-core/fake-browser@1.3.2':
     resolution: {integrity: sha512-jFyPWWz+VkHAC9DRIiIPOyu6X/KlC8dYqSKweHz6tsDb86QawtVgZSpYcM+GOQBlZc5DHFo92jJ7cIq4uBnU0A==}
@@ -559,6 +693,10 @@ packages:
     resolution: {integrity: sha512-1OvF9IbWwaeiM9VhzYXVQacMibxpXOMYVNIvMtKRyX9SImBXpKcFr8XvFDeEslCyuH/t6KRt7HEO94AlP8Iatw==}
     engines: {node: '>=12'}
 
+  assertion-error@2.0.1:
+    resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
+    engines: {node: '>=12'}
+
   async-mutex@0.5.0:
     resolution: {integrity: sha512-1A94B18jkJ3DYq284ohPxoXbfTA5HsQ7/Mf4DEhcyLx3Bz27Rh59iScbB6EPiP+B+joue6YCxcMXSbFC1tZKwA==}
 
@@ -577,6 +715,9 @@ packages:
 
   base64-js@1.5.1:
     resolution: {integrity: sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==}
+
+  bidi-js@1.0.3:
+    resolution: {integrity: sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==}
 
   big-integer@1.6.52:
     resolution: {integrity: sha512-QxD8cf2eVqJOOz63z6JIN9BzvVs/dlySa5HGSBH5xtR8dPteIRQnBxxKqkNTiT6jbDTF6jAfrd4oMcND9RGbQg==}
@@ -617,6 +758,10 @@ packages:
   buffer-from@1.1.2:
     resolution: {integrity: sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==}
 
+  buffer-image-size@0.6.4:
+    resolution: {integrity: sha512-nEh+kZOPY1w+gcCMobZ6ETUp9WfibndnosbpwB1iJk/8Gt5ZF2bhS6+B6bPYz424KtwsR6Rflc3tCz1/ghX2dQ==}
+    engines: {node: '>=4.0'}
+
   buffer@6.0.3:
     resolution: {integrity: sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==}
 
@@ -646,6 +791,10 @@ packages:
 
   caniuse-lite@1.0.30001726:
     resolution: {integrity: sha512-VQAUIUzBiZ/UnlM28fSp2CRF3ivUn1BWEvxMcVTNwpw91Py1pGbPIyIKtd+tzct9C3ouceCVdGAXxZOpZAsgdw==}
+
+  chai@6.2.2:
+    resolution: {integrity: sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==}
+    engines: {node: '>=18'}
 
   chalk@4.1.2:
     resolution: {integrity: sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==}
@@ -762,6 +911,10 @@ packages:
   css-select@5.2.2:
     resolution: {integrity: sha512-TizTzUddG/xYLA3NXodFM0fSbNizXjOKhqiQQwvhlspadZokn1KDy0NZFS0wuEubIYAV5/c1/lAr0TaaFXEXzw==}
 
+  css-tree@3.2.1:
+    resolution: {integrity: sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==}
+    engines: {node: ^10 || ^12.20.0 || ^14.13.0 || >=15.0.0}
+
   css-what@6.2.2:
     resolution: {integrity: sha512-u/O3vwbptzhMs3L1fQE82ZSLHQQfto5gyZzwteVIEyeaY5Fc7R4dapF/BvRoSYFeqfBk4m0V1Vafq5Pjv25wvA==}
     engines: {node: '>= 6'}
@@ -771,6 +924,10 @@ packages:
 
   csstype@3.1.3:
     resolution: {integrity: sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==}
+
+  data-urls@7.0.0:
+    resolution: {integrity: sha512-23XHcCF+coGYevirZceTVD7NdJOqVn+49IHyxgszm+JIiHLoB2TkmPtsYkNWT1pvRSGkc35L6NHs0yHkN2SumA==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
 
   debounce@1.2.1:
     resolution: {integrity: sha512-XRRe6Glud4rd/ZGQfiV1ruXSfbvfJedlV9Y6zOlP+2K04vBYiJEte6stfFkCP03aMnY5tsipamumUjL14fofug==}
@@ -800,6 +957,9 @@ packages:
     peerDependenciesMeta:
       supports-color:
         optional: true
+
+  decimal.js@10.6.0:
+    resolution: {integrity: sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==}
 
   deep-extend@0.6.0:
     resolution: {integrity: sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==}
@@ -887,6 +1047,14 @@ packages:
     resolution: {integrity: sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==}
     engines: {node: '>=0.12'}
 
+  entities@7.0.1:
+    resolution: {integrity: sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA==}
+    engines: {node: '>=0.12'}
+
+  entities@8.0.0:
+    resolution: {integrity: sha512-zwfzJecQ/Uej6tusMqwAqU/6KL2XaB2VZ2Jg54Je6ahNBGNH6Ek6g3jjNCF0fG9EWQKGZNddNjU5F1ZQn/sBnA==}
+    engines: {node: '>=20.19.0'}
+
   environment@1.1.0:
     resolution: {integrity: sha512-xUtoPkMggbz0MPyPiIWr1Kp4aeWJjDZ6SMvURhimjdZgsRuDplF5/s9hcgGhyXMhs+6vpnuoiZ2kFiu3FMnS8Q==}
     engines: {node: '>=18'}
@@ -896,6 +1064,9 @@ packages:
 
   es-module-lexer@1.7.0:
     resolution: {integrity: sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==}
+
+  es-module-lexer@2.3.1:
+    resolution: {integrity: sha512-shc1dbU90Yl/xq1QrC7QRtfcwURZuVRfPhZbDoldJ1cn1gzDvBaBWlv0eFolj5+0znnPJz5TXLxsN77X/12KTA==}
 
   es6-error@4.1.1:
     resolution: {integrity: sha512-Um/+FxMr9CISWh0bi5Zv0iOD+4cFh5qLeks1qhAopKVAJw3drgKbKySikp7wGhDL0HPeaja0P5ULZrxLkniUVg==}
@@ -935,6 +1106,10 @@ packages:
     resolution: {integrity: sha512-UduyVP7TLB5IcAQl+OzLyLcS/l32W/GLg+AhHJ+ow40FOk2U3SAllPwR44v4vmdFwIWqpdwxxpQbF1n5ta9seA==}
     engines: {node: ^14.18.0 || ^16.14.0 || >=18.0.0}
 
+  expect-type@1.4.0:
+    resolution: {integrity: sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==}
+    engines: {node: '>=12.0.0'}
+
   exsolve@1.0.7:
     resolution: {integrity: sha512-VO5fQUzZtI6C+vx4w/4BWJpg3s/5l+6pRQEHzFRM8WFi4XffSP1Z+4qi7GbjWbvRQEbdIco5mIMq+zX4rPuLrw==}
 
@@ -959,6 +1134,15 @@ packages:
 
   fdir@6.4.6:
     resolution: {integrity: sha512-hiFoqpyZcfNm1yc4u8oWCf9A2c4D3QjCrks3zmoVKVxpQRzmPNar1hUJcBG2RQHvEVGDN+Jm81ZheVLAQMK6+w==}
+    peerDependencies:
+      picomatch: ^3 || ^4
+    peerDependenciesMeta:
+      picomatch:
+        optional: true
+
+  fdir@6.5.0:
+    resolution: {integrity: sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==}
+    engines: {node: '>=12.0.0'}
     peerDependencies:
       picomatch: ^3 || ^4
     peerDependenciesMeta:
@@ -1049,15 +1233,27 @@ packages:
   growly@1.3.0:
     resolution: {integrity: sha512-+xGQY0YyAWCnqy7Cd++hc2JqMYzlm0dG30Jd0beaA64sROr8C4nt8Yc9V5Ro3avlSUDTN0ulqP/VBKi1/lLygw==}
 
+  happy-dom@20.10.6:
+    resolution: {integrity: sha512-6QD0ilzDDt93tX44y8tbmZdAcdTRYDhUP+Asgi6pC8Pp5IA3cvaZGyoVN/EGtlq9ziT65iPuBBn3ASLr6hCgVw==}
+    engines: {node: '>=20.0.0'}
+
   has-flag@4.0.0:
     resolution: {integrity: sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==}
     engines: {node: '>=8'}
+
+  he@1.2.0:
+    resolution: {integrity: sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==}
+    hasBin: true
 
   highlight.js@10.7.3:
     resolution: {integrity: sha512-tzcUFauisWKNHaRkN4Wjl/ZA07gENAjFl3J/c480dprkGTg5EQstgaNFqBfUqCq54kZRIEcreTsAgF/m2quD7A==}
 
   hookable@5.5.3:
     resolution: {integrity: sha512-Yc+BQe8SvoXH1643Qez1zqLRmbA5rCL+sSmk6TVos0LWVfNIB7PGncdlId77WzLGSIB5KaWgTaNTs2lNVEI6VQ==}
+
+  html-encoding-sniffer@6.0.0:
+    resolution: {integrity: sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
 
   html-escaper@3.0.3:
     resolution: {integrity: sha512-RuMffC89BOWQoY0WKGpIhn5gX3iI54O6nRA0yC124NYVtzjmFWBIiFd8M0x+ZdX0P9R4lADg1mgP8C7PxGOWuQ==}
@@ -1225,6 +1421,15 @@ packages:
   js-tokens@9.0.1:
     resolution: {integrity: sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==}
 
+  jsdom@29.1.1:
+    resolution: {integrity: sha512-ECi4Fi2f7BdJtUKTflYRTiaMxIB0O6zfR1fX0GXpUrf6flp8QIYn1UT20YQqdSOfk2dfkCwS8LAFoJDEppNK5Q==}
+    engines: {node: ^20.19.0 || ^22.13.0 || >=24.0.0}
+    peerDependencies:
+      canvas: ^3.0.0
+    peerDependenciesMeta:
+      canvas:
+        optional: true
+
   jsesc@3.1.0:
     resolution: {integrity: sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==}
     engines: {node: '>=6'}
@@ -1302,11 +1507,18 @@ packages:
     resolution: {integrity: sha512-9ie8ItPR6tjY5uYJh8K/Zrv/RMZ5VOlOWvtZdEHYSTFKZfIBPQa9tOAEeAWhd+AnIneLJ22w5fjOYtoutpWq5w==}
     engines: {node: '>=18'}
 
+  lru-cache@11.5.2:
+    resolution: {integrity: sha512-4pfM1Ff0x50o0tQwb5ucw/RzNyD0/YJME6IVcStalZuMWxdt3sR3huStTtxz4PUmvZfRguvDejasvQ2kifR11g==}
+    engines: {node: 20 || >=22}
+
   lru-cache@5.1.1:
     resolution: {integrity: sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==}
 
   magic-string@0.30.17:
     resolution: {integrity: sha512-sNPKHvyjVf7gyjwS4xGTaW/mCnF8wnjtifKBEhxfZ7E/S8tQ0rssrwGNn6q8JH/ohItJfSQp9mBtQYuTlH5QnA==}
+
+  magic-string@0.30.21:
+    resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
 
   magicast@0.3.5:
     resolution: {integrity: sha512-L0WhttDl+2BOsybvEOLK7fW3UA0OQ0IQ2d6Zl2x/a6vVRs3bAY0ECOSHHeL5jD+SbOpOCUEi0y1DgHEn9Qn1AQ==}
@@ -1319,6 +1531,9 @@ packages:
 
   marky@1.3.0:
     resolution: {integrity: sha512-ocnPZQLNpvbedwTy9kNrQEsknEfgvcLMvOtz3sFeWApDq1MXH1TqkCIx58xlpESsfwQOnuBO9beyQuNGzVvuhQ==}
+
+  mdn-data@2.27.1:
+    resolution: {integrity: sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==}
 
   merge-stream@2.0.0:
     resolution: {integrity: sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==}
@@ -1385,6 +1600,9 @@ packages:
     resolution: {integrity: sha512-dPEtOeMvF9VMcYV/1Wb8CPoVAXtp6MKMlcbAt4ddqmGqUJ6fQZFXkNZNkNlfevtNkGtaSoXf/vNNNSvgrdXwtA==}
     engines: {node: '>= 6.13.0'}
 
+  node-html-parser@7.1.0:
+    resolution: {integrity: sha512-iJo8b2uYGT40Y8BTyy5ufL6IVbN8rbm/1QK2xffXU/1a/v3AAa0d1YAoqBNYqaS4R/HajkWIpIfdE6KcyFh1AQ==}
+
   node-notifier@10.0.1:
     resolution: {integrity: sha512-YX7TSyDukOZ0g+gmzjB6abKu+hTGvO8+8+gIFDsRCU2t8fLV/P2unmt+LGFaIa4y64aX98Qksa97rgz4vMNeLQ==}
 
@@ -1414,6 +1632,10 @@ packages:
   object-assign@4.1.1:
     resolution: {integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==}
     engines: {node: '>=0.10.0'}
+
+  obug@2.1.3:
+    resolution: {integrity: sha512-9miFgM2OFba7hB+pRgvtV84pYTBaoTHohvmIgiRt6dRIzbwEOIaNaP+dIlGs2fNFoB0SeISs0Jz5WFVRid6Xyg==}
+    engines: {node: '>=12.20.0'}
 
   ofetch@1.4.1:
     resolution: {integrity: sha512-QZj2DfGplQAr2oj9KzceK9Hwz6Whxazmn85yYeVuS3u9XTMOGMRx0kO95MQ+vLsj/S/NwBDMMLU5hpxvI6Tklw==}
@@ -1484,6 +1706,9 @@ packages:
   parse5@6.0.1:
     resolution: {integrity: sha512-Ofn/CTFzRGTTxwpNEs9PP93gXShHcTq255nzRYSKe8AkVpZY7e1fpmTfOyoIvjP5HG7Z2ZM7VS9PPhQGW2pOpw==}
 
+  parse5@8.0.1:
+    resolution: {integrity: sha512-z1e/HMG90obSGeidlli3hj7cbocou0/wa5HacvI3ASx34PecNjNQeaHNo5WIZpWofN9kgkqV1q5YvXe3F0FoPw==}
+
   path-key@3.1.1:
     resolution: {integrity: sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==}
     engines: {node: '>=8'}
@@ -1510,6 +1735,10 @@ packages:
 
   picomatch@4.0.2:
     resolution: {integrity: sha512-M7BAV6Rlcy5u+m6oPhAPFgJTzAioX/6B0DxyvDlo9l8+T3nLKbrczg2WLUyzd45L8RqfUMyGPzekbMvX2Ldkwg==}
+    engines: {node: '>=12'}
+
+  picomatch@4.0.5:
+    resolution: {integrity: sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==}
     engines: {node: '>=12'}
 
   pino-abstract-transport@2.0.0:
@@ -1556,6 +1785,10 @@ packages:
 
   pump@3.0.3:
     resolution: {integrity: sha512-todwxLMY7/heScKmntwQG8CXVkWUOdYxIvY2s0VWAAMh/nd8SoYiRaKjlr7+iCs984f2P8zvrfWcDDYVb73NfA==}
+
+  punycode@2.3.1:
+    resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
+    engines: {node: '>=6'}
 
   pupa@3.1.0:
     resolution: {integrity: sha512-FLpr4flz5xZTSJxSeaheeMKN/EDzMdK7b8PTOC6a5PYFKTucWbdqjgqaEyH0shFiSJrVB1+Qqi4Tk19ccU6Aug==}
@@ -1620,6 +1853,10 @@ packages:
     resolution: {integrity: sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==}
     engines: {node: '>=0.10.0'}
 
+  require-from-string@2.0.2:
+    resolution: {integrity: sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==}
+    engines: {node: '>=0.10.0'}
+
   restore-cursor@4.0.0:
     resolution: {integrity: sha512-I9fPXU9geO9bHOt9pHHOhOkYerIMsmVaWB0rA2AI9ERh/+x/i7MV5HKBNrg+ljO5eoPVgCcnFuRjJ9uH6I/3eg==}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
@@ -1664,6 +1901,10 @@ packages:
   sax@1.4.1:
     resolution: {integrity: sha512-+aWOz7yVScEGoKNd4PA10LZ8sk0A/z5+nXQG5giUO5rprX9jgYsTdov9qCchZiPIZezbZH+jRut8nPodFAX4Jg==}
 
+  saxes@6.0.0:
+    resolution: {integrity: sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==}
+    engines: {node: '>=v12.22.7'}
+
   scheduler@0.26.0:
     resolution: {integrity: sha512-NlHwttCI/l5gCPR3D1nNXtWABUmBwvZpEQiD4IXSbIDq8BzLIK/7Ir5gTFSGZDUu37K5cMNp0hFtzO38sC7gWA==}
 
@@ -1699,6 +1940,9 @@ packages:
 
   shellwords@0.1.1:
     resolution: {integrity: sha512-vFwSUfQvqybiICwZY5+DAWIPLKsWO31Q91JSKl3UYv+K5c2QRPzn0qzec6QPu1Qc9eHYItiP3NdJqNVqetYAww==}
+
+  siginfo@2.0.0:
+    resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
 
   signal-exit@3.0.7:
     resolution: {integrity: sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==}
@@ -1745,6 +1989,12 @@ packages:
 
   split@1.0.1:
     resolution: {integrity: sha512-mTyOoPbrivtXnwnIxZRFYRrPNtEFKlpB2fvjSnCQUiAA6qAZzqwna5envK4uk6OIeP17CsdF3rSBGYVBsU0Tkg==}
+
+  stackback@0.0.2:
+    resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
+
+  std-env@4.2.0:
+    resolution: {integrity: sha512-oCUKSupKTHX53EyjDtuZQ64pjLJ6yYCtpmEw0goYxtjG9KpbRe8KAsl2tBUGU9DyMcJ0RwJ8GqJAFzMXcXW1Rw==}
 
   stdin-discarder@0.1.0:
     resolution: {integrity: sha512-xhV7w8S+bUwlPTb4bAOUQhv8/cSS5offJuX8GQGq32ONF0ZtDWKfkdomM3HMRA+LhX6um/FZ0COqlwsjD53LeQ==}
@@ -1806,6 +2056,9 @@ packages:
     resolution: {integrity: sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==}
     engines: {node: '>=8'}
 
+  symbol-tree@3.2.4:
+    resolution: {integrity: sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==}
+
   thenify-all@1.6.0:
     resolution: {integrity: sha512-RNxQH/qI8/t3thXJDwcstUO4zeqo64+Uy/+sNVRBx4Xn2OX+OZ9oP+iJnNFqplFra2ZUVeKCSa2oVWi3T4uVmA==}
     engines: {node: '>=0.8'}
@@ -1819,16 +2072,38 @@ packages:
   through@2.3.8:
     resolution: {integrity: sha512-w89qg7PI8wAdvX60bMDP+bFoD5Dvhm9oLheFp5O4a2QF0cSBGsBX4qZmadPMvVqlLJBBci+WqGGOAPvcDeNSVg==}
 
+  tinybench@2.9.0:
+    resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
+
   tinyexec@0.3.2:
     resolution: {integrity: sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==}
+
+  tinyexec@1.2.4:
+    resolution: {integrity: sha512-SHf/r48b7vOrjve9PxJo3MN5v5yuyjHvdUcrQffT3WXMUfnGmHDVbC4k3sHJaJTgZCwpUplIaAo5ANtMyp3YHg==}
+    engines: {node: '>=18'}
 
   tinyglobby@0.2.14:
     resolution: {integrity: sha512-tX5e7OM1HnYr2+a2C/4V0htOcSQcoSTH9KgJnVvNm5zm/cyEWKJ7j7YutsH9CxMdtOkkLFy2AHrMci9IM8IPZQ==}
     engines: {node: '>=12.0.0'}
 
+  tinyglobby@0.2.17:
+    resolution: {integrity: sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==}
+    engines: {node: '>=12.0.0'}
+
+  tinyrainbow@3.1.0:
+    resolution: {integrity: sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==}
+    engines: {node: '>=14.0.0'}
+
   titleize@3.0.0:
     resolution: {integrity: sha512-KxVu8EYHDPBdUYdKZdKtU2aj2XfEx9AfjXxE/Aj0vT06w2icA09Vus1rh6eSu1y01akYg6BjIK/hxyLJINoMLQ==}
     engines: {node: '>=12'}
+
+  tldts-core@7.4.8:
+    resolution: {integrity: sha512-c1P7u0EhACHj7lPy4MJm8iTFEU8+nB0LCtddH0fhP7noaVoXAqafMtOOeX+ulpuPBqnrRgRhw494RICT3mbhnw==}
+
+  tldts@7.4.8:
+    resolution: {integrity: sha512-htwgN/8KRB3z3vnC0BOETVh2m499g5GmyTK9Wq5JBLX3FNz6tSBveAd+fQhzy9hkjif8vy2jwDMR1sGhLtZl2A==}
+    hasBin: true
 
   tmp@0.2.3:
     resolution: {integrity: sha512-nZD7m9iCPC5g0pYmcaxogYKggSfLsdxl8of3Q/oIbqCqLLIO9IAF0GWjX1z9NZRHPiXv8Wex4yDCaZsgEw0Y8w==}
@@ -1837,6 +2112,14 @@ packages:
   to-regex-range@5.0.1:
     resolution: {integrity: sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==}
     engines: {node: '>=8.0'}
+
+  tough-cookie@6.0.2:
+    resolution: {integrity: sha512-exgYmnmL/sJpR3upZfXG5PoatXQii55xAiXGXzY+sROLZ/Y+SLcp9PgJNI9Vz37HpQ74WvDcLT8eqm+kV3FzrA==}
+    engines: {node: '>=16'}
+
+  tr46@6.0.0:
+    resolution: {integrity: sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==}
+    engines: {node: '>=20'}
 
   tslib@2.8.1:
     resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
@@ -1865,6 +2148,10 @@ packages:
 
   undici-types@7.8.0:
     resolution: {integrity: sha512-9UJ2xGDvQ43tYyVMpuHlsgApydB8ZKfVYTsLDhXkFL/6gfkp+U8xTGdh8pMJv1SpZna0zxG1DwsKZsreLbXBxw==}
+
+  undici@7.28.0:
+    resolution: {integrity: sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==}
+    engines: {node: '>=20.18.1'}
 
   unimport@5.0.1:
     resolution: {integrity: sha512-1YWzPj6wYhtwHE+9LxRlyqP4DiRrhGfJxdtH475im8ktyZXO3jHj/3PZ97zDdvkYoovFdi0K4SKl3a7l92v3sQ==}
@@ -1901,6 +2188,7 @@ packages:
 
   uuid@8.3.2:
     resolution: {integrity: sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==}
+    deprecated: uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).
     hasBin: true
 
   vite-node@3.2.4:
@@ -1948,6 +2236,51 @@ packages:
       yaml:
         optional: true
 
+  vitest@4.1.10:
+    resolution: {integrity: sha512-R9jUTe5S4Qb0HCd4TNqpC7oGcrMssMRGXLW80ubjWsW9VH5GF8y1Y0SFLY9AbqSk6nt0PnOx4H4WNJYZ13GUPw==}
+    engines: {node: ^20.0.0 || ^22.0.0 || >=24.0.0}
+    hasBin: true
+    peerDependencies:
+      '@edge-runtime/vm': '*'
+      '@opentelemetry/api': ^1.9.0
+      '@types/node': ^20.0.0 || ^22.0.0 || >=24.0.0
+      '@vitest/browser-playwright': 4.1.10
+      '@vitest/browser-preview': 4.1.10
+      '@vitest/browser-webdriverio': 4.1.10
+      '@vitest/coverage-istanbul': 4.1.10
+      '@vitest/coverage-v8': 4.1.10
+      '@vitest/ui': 4.1.10
+      happy-dom: '*'
+      jsdom: '*'
+      vite: ^6.0.0 || ^7.0.0 || ^8.0.0
+    peerDependenciesMeta:
+      '@edge-runtime/vm':
+        optional: true
+      '@opentelemetry/api':
+        optional: true
+      '@types/node':
+        optional: true
+      '@vitest/browser-playwright':
+        optional: true
+      '@vitest/browser-preview':
+        optional: true
+      '@vitest/browser-webdriverio':
+        optional: true
+      '@vitest/coverage-istanbul':
+        optional: true
+      '@vitest/coverage-v8':
+        optional: true
+      '@vitest/ui':
+        optional: true
+      happy-dom:
+        optional: true
+      jsdom:
+        optional: true
+
+  w3c-xmlserializer@5.0.0:
+    resolution: {integrity: sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==}
+    engines: {node: '>=18'}
+
   watchpack@2.4.2:
     resolution: {integrity: sha512-TnbFSbcOCcDgjZ4piURLCbJ3nJhznVh9kw6F6iokjiFPl8ONxe9A6nMDVXDiNbrSfLILs6vB07F7wLBrwPYzJw==}
     engines: {node: '>=10.13.0'}
@@ -1959,8 +2292,24 @@ packages:
     resolution: {integrity: sha512-u/IiZaZ7dHFqTM1MLF27rBy8mS9fEEsqoOKL0u+kQdOLmEioA/0Szp67ADd3WAJZLd8/hO8cFST1IC/YMXKIjQ==}
     engines: {node: '>=18.0.0', npm: '>=8.0.0'}
 
+  webidl-conversions@8.0.1:
+    resolution: {integrity: sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ==}
+    engines: {node: '>=20'}
+
   webpack-virtual-modules@0.6.2:
     resolution: {integrity: sha512-66/V2i5hQanC51vBQKPH4aI8NMAcBW59FVBs+rC7eGHupMyfn34q7rZIE+ETlJ+XTevqfUhVVBgSUNSW2flEUQ==}
+
+  whatwg-mimetype@3.0.0:
+    resolution: {integrity: sha512-nt+N2dzIutVRxARx1nghPKGv1xHikU7HKdfafKkLNLindmPU/ch3U31NOCGGA/dmPcmb1VlofO0vnKAcsm0o/Q==}
+    engines: {node: '>=12'}
+
+  whatwg-mimetype@5.0.0:
+    resolution: {integrity: sha512-sXcNcHOC51uPGF0P/D4NVtrkjSU2fNsm9iog4ZvZJsL3rjoDAzXZhkm2MWt1y+PUdggKAYVoMAIYcs78wJ51Cw==}
+    engines: {node: '>=20'}
+
+  whatwg-url@16.0.1:
+    resolution: {integrity: sha512-1to4zXBxmXHV3IiSSEInrreIlu02vUOvrhxJJH5vcxYTBDAx51cqZiKdyTxlecdKNSjj8EcxGBxNf6Vg+945gw==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
 
   when-exit@2.1.4:
     resolution: {integrity: sha512-4rnvd3A1t16PWzrBUcSDZqcAmsUIy4minDXT/CZ8F2mVDgd65i4Aalimgz1aQkRGU0iH5eT5+6Rx2TK8o443Pg==}
@@ -1975,6 +2324,11 @@ packages:
   which@2.0.2:
     resolution: {integrity: sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==}
     engines: {node: '>= 8'}
+    hasBin: true
+
+  why-is-node-running@2.3.0:
+    resolution: {integrity: sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==}
+    engines: {node: '>=8'}
     hasBin: true
 
   widest-line@5.0.0:
@@ -2007,6 +2361,18 @@ packages:
       utf-8-validate:
         optional: true
 
+  ws@8.21.1:
+    resolution: {integrity: sha512-+0NTnW77fFN/DjQi6k/Sq/Yvk4Sgajw7urW8V+asjXnRgDs9gyGkdb7EzgfhA4goXsRIZKE28fzIXBHEzhuiWw==}
+    engines: {node: '>=10.0.0'}
+    peerDependencies:
+      bufferutil: ^4.0.1
+      utf-8-validate: '>=5.0.2'
+    peerDependenciesMeta:
+      bufferutil:
+        optional: true
+      utf-8-validate:
+        optional: true
+
   wxt@0.20.7:
     resolution: {integrity: sha512-KABq5i3CnXMUaJTcORGDLCi04K/IceUVAx5rler2QbZpLvS13OUOO0k+4s/7LI3+N8zXLh/GlQArMyJfk3M2yQ==}
     hasBin: true
@@ -2015,6 +2381,10 @@ packages:
     resolution: {integrity: sha512-GCPAHLvrIH13+c0SuacwvRYj2SxJXQ4kaVTT5xgL3kPrz56XxkF21IGhjSE1+W0aw7gpBWRGXLCPnPby6lSpmQ==}
     engines: {node: '>=12'}
 
+  xml-name-validator@5.0.0:
+    resolution: {integrity: sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==}
+    engines: {node: '>=18'}
+
   xml2js@0.6.2:
     resolution: {integrity: sha512-T4rieHaC1EXcES0Kxxj4JWgaUQHDk+qwHcYOCFHfiwKz7tOVPLq7Hjq9dM1WCMhylqMEfP7hMcOIChvotiZegA==}
     engines: {node: '>=4.0.0'}
@@ -2022,6 +2392,9 @@ packages:
   xmlbuilder@11.0.1:
     resolution: {integrity: sha512-fDlsI/kFEx7gLvbecc0/ohLG50fugQp8ryHzMTuW9vSa1GJ0XYWKnhsUx7oie3G98+r56aTQIUB4kht42R3JvA==}
     engines: {node: '>=4.0'}
+
+  xmlchars@2.2.0:
+    resolution: {integrity: sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==}
 
   y18n@5.0.8:
     resolution: {integrity: sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==}
@@ -2075,6 +2448,26 @@ snapshots:
     dependencies:
       '@jridgewell/gen-mapping': 0.3.8
       '@jridgewell/trace-mapping': 0.3.25
+
+  '@asamuzakjp/css-color@5.1.11':
+    dependencies:
+      '@asamuzakjp/generational-cache': 1.0.1
+      '@csstools/css-calc': 3.2.1(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-color-parser': 4.1.9(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-parser-algorithms': 4.0.0(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-tokenizer': 4.0.0
+
+  '@asamuzakjp/dom-selector@7.1.1':
+    dependencies:
+      '@asamuzakjp/generational-cache': 1.0.1
+      '@asamuzakjp/nwsapi': 2.3.9
+      bidi-js: 1.0.3
+      css-tree: 3.2.1
+      is-potential-custom-element-name: 1.0.1
+
+  '@asamuzakjp/generational-cache@1.0.1': {}
+
+  '@asamuzakjp/nwsapi@2.3.9': {}
 
   '@babel/code-frame@7.27.1':
     dependencies:
@@ -2190,6 +2583,34 @@ snapshots:
       '@babel/helper-string-parser': 7.27.1
       '@babel/helper-validator-identifier': 7.27.1
 
+  '@bramus/specificity@2.4.2':
+    dependencies:
+      css-tree: 3.2.1
+
+  '@csstools/color-helpers@6.1.0': {}
+
+  '@csstools/css-calc@3.2.1(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)':
+    dependencies:
+      '@csstools/css-parser-algorithms': 4.0.0(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-tokenizer': 4.0.0
+
+  '@csstools/css-color-parser@4.1.9(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)':
+    dependencies:
+      '@csstools/color-helpers': 6.1.0
+      '@csstools/css-calc': 3.2.1(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-parser-algorithms': 4.0.0(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-tokenizer': 4.0.0
+
+  '@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0)':
+    dependencies:
+      '@csstools/css-tokenizer': 4.0.0
+
+  '@csstools/css-syntax-patches-for-csstree@1.1.6(css-tree@3.2.1)':
+    optionalDependencies:
+      css-tree: 3.2.1
+
+  '@csstools/css-tokenizer@4.0.0': {}
+
   '@devicefarmer/adbkit-logcat@2.1.3': {}
 
   '@devicefarmer/adbkit-monkey@1.2.1': {}
@@ -2281,6 +2702,8 @@ snapshots:
   '@esbuild/win32-x64@0.25.5':
     optional: true
 
+  '@exodus/bytes@1.15.1': {}
+
   '@isaacs/balanced-match@4.0.1': {}
 
   '@isaacs/brace-expansion@5.0.0':
@@ -2298,6 +2721,8 @@ snapshots:
   '@jridgewell/set-array@1.2.1': {}
 
   '@jridgewell/sourcemap-codec@1.5.0': {}
+
+  '@jridgewell/sourcemap-codec@1.5.5': {}
 
   '@jridgewell/trace-mapping@0.3.25':
     dependencies:
@@ -2390,6 +2815,8 @@ snapshots:
   '@rollup/rollup-win32-x64-msvc@4.44.1':
     optional: true
 
+  '@standard-schema/spec@1.1.0': {}
+
   '@types/babel__core@7.20.5':
     dependencies:
       '@babel/parser': 7.27.7
@@ -2410,6 +2837,13 @@ snapshots:
   '@types/babel__traverse@7.20.7':
     dependencies:
       '@babel/types': 7.27.7
+
+  '@types/chai@5.2.3':
+    dependencies:
+      '@types/deep-eql': 4.0.2
+      assertion-error: 2.0.1
+
+  '@types/deep-eql@4.0.2': {}
 
   '@types/estree@1.0.8': {}
 
@@ -2435,6 +2869,12 @@ snapshots:
     dependencies:
       csstype: 3.1.3
 
+  '@types/whatwg-mimetype@3.0.2': {}
+
+  '@types/ws@8.18.1':
+    dependencies:
+      '@types/node': 24.0.7
+
   '@types/yauzl@2.10.3':
     dependencies:
       '@types/node': 24.0.7
@@ -2451,6 +2891,47 @@ snapshots:
       vite: 6.3.5(@types/node@24.0.7)(jiti@2.4.2)
     transitivePeerDependencies:
       - supports-color
+
+  '@vitest/expect@4.1.10':
+    dependencies:
+      '@standard-schema/spec': 1.1.0
+      '@types/chai': 5.2.3
+      '@vitest/spy': 4.1.10
+      '@vitest/utils': 4.1.10
+      chai: 6.2.2
+      tinyrainbow: 3.1.0
+
+  '@vitest/mocker@4.1.10(vite@6.3.5(@types/node@24.0.7)(jiti@2.4.2))':
+    dependencies:
+      '@vitest/spy': 4.1.10
+      estree-walker: 3.0.3
+      magic-string: 0.30.21
+    optionalDependencies:
+      vite: 6.3.5(@types/node@24.0.7)(jiti@2.4.2)
+
+  '@vitest/pretty-format@4.1.10':
+    dependencies:
+      tinyrainbow: 3.1.0
+
+  '@vitest/runner@4.1.10':
+    dependencies:
+      '@vitest/utils': 4.1.10
+      pathe: 2.0.3
+
+  '@vitest/snapshot@4.1.10':
+    dependencies:
+      '@vitest/pretty-format': 4.1.10
+      '@vitest/utils': 4.1.10
+      magic-string: 0.30.21
+      pathe: 2.0.3
+
+  '@vitest/spy@4.1.10': {}
+
+  '@vitest/utils@4.1.10':
+    dependencies:
+      '@vitest/pretty-format': 4.1.10
+      convert-source-map: 2.0.0
+      tinyrainbow: 3.1.0
 
   '@webext-core/fake-browser@1.3.2':
     dependencies:
@@ -2508,6 +2989,8 @@ snapshots:
 
   array-union@3.0.1: {}
 
+  assertion-error@2.0.1: {}
+
   async-mutex@0.5.0:
     dependencies:
       tslib: 2.8.1
@@ -2524,6 +3007,10 @@ snapshots:
   balanced-match@1.0.2: {}
 
   base64-js@1.5.1: {}
+
+  bidi-js@1.0.3:
+    dependencies:
+      require-from-string: 2.0.2
 
   big-integer@1.6.52: {}
 
@@ -2572,6 +3059,10 @@ snapshots:
 
   buffer-from@1.1.2: {}
 
+  buffer-image-size@0.6.4:
+    dependencies:
+      '@types/node': 24.0.7
+
   buffer@6.0.3:
     dependencies:
       base64-js: 1.5.1
@@ -2607,6 +3098,8 @@ snapshots:
   camelcase@8.0.0: {}
 
   caniuse-lite@1.0.30001726: {}
+
+  chai@6.2.2: {}
 
   chalk@4.1.2:
     dependencies:
@@ -2733,11 +3226,23 @@ snapshots:
       domutils: 3.2.2
       nth-check: 2.1.1
 
+  css-tree@3.2.1:
+    dependencies:
+      mdn-data: 2.27.1
+      source-map-js: 1.2.1
+
   css-what@6.2.2: {}
 
   cssom@0.5.0: {}
 
   csstype@3.1.3: {}
+
+  data-urls@7.0.0:
+    dependencies:
+      whatwg-mimetype: 5.0.0
+      whatwg-url: 16.0.1
+    transitivePeerDependencies:
+      - '@noble/hashes'
 
   debounce@1.2.1: {}
 
@@ -2752,6 +3257,8 @@ snapshots:
   debug@4.4.1:
     dependencies:
       ms: 2.1.3
+
+  decimal.js@10.6.0: {}
 
   deep-extend@0.6.0: {}
 
@@ -2830,6 +3337,10 @@ snapshots:
 
   entities@6.0.1: {}
 
+  entities@7.0.1: {}
+
+  entities@8.0.0: {}
+
   environment@1.1.0: {}
 
   error-ex@1.3.2:
@@ -2837,6 +3348,8 @@ snapshots:
       is-arrayish: 0.2.1
 
   es-module-lexer@1.7.0: {}
+
+  es-module-lexer@2.3.1: {}
 
   es6-error@4.1.1: {}
 
@@ -2906,6 +3419,8 @@ snapshots:
       signal-exit: 3.0.7
       strip-final-newline: 3.0.0
 
+  expect-type@1.4.0: {}
+
   exsolve@1.0.7: {}
 
   extract-zip@2.0.1:
@@ -2939,6 +3454,10 @@ snapshots:
   fdir@6.4.6(picomatch@4.0.2):
     optionalDependencies:
       picomatch: 4.0.2
+
+  fdir@6.5.0(picomatch@4.0.5):
+    optionalDependencies:
+      picomatch: 4.0.5
 
   filesize@10.1.6: {}
 
@@ -3017,11 +3536,32 @@ snapshots:
 
   growly@1.3.0: {}
 
+  happy-dom@20.10.6:
+    dependencies:
+      '@types/node': 24.0.7
+      '@types/whatwg-mimetype': 3.0.2
+      '@types/ws': 8.18.1
+      buffer-image-size: 0.6.4
+      entities: 7.0.1
+      whatwg-mimetype: 3.0.0
+      ws: 8.21.1
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
+
   has-flag@4.0.0: {}
+
+  he@1.2.0: {}
 
   highlight.js@10.7.3: {}
 
   hookable@5.5.3: {}
+
+  html-encoding-sniffer@6.0.0:
+    dependencies:
+      '@exodus/bytes': 1.15.1
+    transitivePeerDependencies:
+      - '@noble/hashes'
 
   html-escaper@3.0.3: {}
 
@@ -3133,6 +3673,32 @@ snapshots:
 
   js-tokens@9.0.1: {}
 
+  jsdom@29.1.1:
+    dependencies:
+      '@asamuzakjp/css-color': 5.1.11
+      '@asamuzakjp/dom-selector': 7.1.1
+      '@bramus/specificity': 2.4.2
+      '@csstools/css-syntax-patches-for-csstree': 1.1.6(css-tree@3.2.1)
+      '@exodus/bytes': 1.15.1
+      css-tree: 3.2.1
+      data-urls: 7.0.0
+      decimal.js: 10.6.0
+      html-encoding-sniffer: 6.0.0
+      is-potential-custom-element-name: 1.0.1
+      lru-cache: 11.5.2
+      parse5: 8.0.1
+      saxes: 6.0.0
+      symbol-tree: 3.2.4
+      tough-cookie: 6.0.2
+      undici: 7.28.0
+      w3c-xmlserializer: 5.0.0
+      webidl-conversions: 8.0.1
+      whatwg-mimetype: 5.0.0
+      whatwg-url: 16.0.1
+      xml-name-validator: 5.0.0
+    transitivePeerDependencies:
+      - '@noble/hashes'
+
   jsesc@3.1.0: {}
 
   json-parse-even-better-errors@3.0.2: {}
@@ -3222,6 +3788,8 @@ snapshots:
       strip-ansi: 7.1.0
       wrap-ansi: 9.0.0
 
+  lru-cache@11.5.2: {}
+
   lru-cache@5.1.1:
     dependencies:
       yallist: 3.1.1
@@ -3229,6 +3797,10 @@ snapshots:
   magic-string@0.30.17:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.0
+
+  magic-string@0.30.21:
+    dependencies:
+      '@jridgewell/sourcemap-codec': 1.5.5
 
   magicast@0.3.5:
     dependencies:
@@ -3241,6 +3813,8 @@ snapshots:
   many-keys-map@2.0.1: {}
 
   marky@1.3.0: {}
+
+  mdn-data@2.27.1: {}
 
   merge-stream@2.0.0: {}
 
@@ -3299,6 +3873,11 @@ snapshots:
 
   node-forge@1.3.1: {}
 
+  node-html-parser@7.1.0:
+    dependencies:
+      css-select: 5.2.2
+      he: 1.2.0
+
   node-notifier@10.0.1:
     dependencies:
       growly: 1.3.0
@@ -3333,6 +3912,8 @@ snapshots:
       tinyexec: 0.3.2
 
   object-assign@4.1.1: {}
+
+  obug@2.1.3: {}
 
   ofetch@1.4.1:
     dependencies:
@@ -3431,6 +4012,10 @@ snapshots:
 
   parse5@6.0.1: {}
 
+  parse5@8.0.1:
+    dependencies:
+      entities: 8.0.0
+
   path-key@3.1.1: {}
 
   path-key@4.0.0: {}
@@ -3446,6 +4031,8 @@ snapshots:
   picomatch@2.3.1: {}
 
   picomatch@4.0.2: {}
+
+  picomatch@4.0.5: {}
 
   pino-abstract-transport@2.0.0:
     dependencies:
@@ -3525,6 +4112,8 @@ snapshots:
       end-of-stream: 1.4.5
       once: 1.4.0
 
+  punycode@2.3.1: {}
+
   pupa@3.1.0:
     dependencies:
       escape-goat: 4.0.0
@@ -3588,6 +4177,8 @@ snapshots:
 
   require-directory@2.1.1: {}
 
+  require-from-string@2.0.2: {}
+
   restore-cursor@4.0.0:
     dependencies:
       onetime: 5.1.2
@@ -3646,6 +4237,10 @@ snapshots:
 
   sax@1.4.1: {}
 
+  saxes@6.0.0:
+    dependencies:
+      xmlchars: 2.2.0
+
   scheduler@0.26.0: {}
 
   scule@1.3.0: {}
@@ -3670,6 +4265,8 @@ snapshots:
   shell-quote@1.7.3: {}
 
   shellwords@0.1.1: {}
+
+  siginfo@2.0.0: {}
 
   signal-exit@3.0.7: {}
 
@@ -3712,6 +4309,10 @@ snapshots:
   split@1.0.1:
     dependencies:
       through: 2.3.8
+
+  stackback@0.0.2: {}
+
+  std-env@4.2.0: {}
 
   stdin-discarder@0.1.0:
     dependencies:
@@ -3767,6 +4368,8 @@ snapshots:
     dependencies:
       has-flag: 4.0.0
 
+  symbol-tree@3.2.4: {}
+
   thenify-all@1.6.0:
     dependencies:
       thenify: 3.3.1
@@ -3781,20 +4384,45 @@ snapshots:
 
   through@2.3.8: {}
 
+  tinybench@2.9.0: {}
+
   tinyexec@0.3.2: {}
+
+  tinyexec@1.2.4: {}
 
   tinyglobby@0.2.14:
     dependencies:
       fdir: 6.4.6(picomatch@4.0.2)
       picomatch: 4.0.2
 
+  tinyglobby@0.2.17:
+    dependencies:
+      fdir: 6.5.0(picomatch@4.0.5)
+      picomatch: 4.0.5
+
+  tinyrainbow@3.1.0: {}
+
   titleize@3.0.0: {}
+
+  tldts-core@7.4.8: {}
+
+  tldts@7.4.8:
+    dependencies:
+      tldts-core: 7.4.8
 
   tmp@0.2.3: {}
 
   to-regex-range@5.0.1:
     dependencies:
       is-number: 7.0.0
+
+  tough-cookie@6.0.2:
+    dependencies:
+      tldts: 7.4.8
+
+  tr46@6.0.0:
+    dependencies:
+      punycode: 2.3.1
 
   tslib@2.8.1: {}
 
@@ -3811,6 +4439,8 @@ snapshots:
   uhyphen@0.2.0: {}
 
   undici-types@7.8.0: {}
+
+  undici@7.28.0: {}
 
   unimport@5.0.1:
     dependencies:
@@ -3891,15 +4521,48 @@ snapshots:
   vite@6.3.5(@types/node@24.0.7)(jiti@2.4.2):
     dependencies:
       esbuild: 0.25.5
-      fdir: 6.4.6(picomatch@4.0.2)
-      picomatch: 4.0.2
+      fdir: 6.5.0(picomatch@4.0.5)
+      picomatch: 4.0.5
       postcss: 8.5.6
       rollup: 4.44.1
-      tinyglobby: 0.2.14
+      tinyglobby: 0.2.17
     optionalDependencies:
       '@types/node': 24.0.7
       fsevents: 2.3.3
       jiti: 2.4.2
+
+  vitest@4.1.10(@types/node@24.0.7)(happy-dom@20.10.6)(jsdom@29.1.1)(vite@6.3.5(@types/node@24.0.7)(jiti@2.4.2)):
+    dependencies:
+      '@vitest/expect': 4.1.10
+      '@vitest/mocker': 4.1.10(vite@6.3.5(@types/node@24.0.7)(jiti@2.4.2))
+      '@vitest/pretty-format': 4.1.10
+      '@vitest/runner': 4.1.10
+      '@vitest/snapshot': 4.1.10
+      '@vitest/spy': 4.1.10
+      '@vitest/utils': 4.1.10
+      es-module-lexer: 2.3.1
+      expect-type: 1.4.0
+      magic-string: 0.30.21
+      obug: 2.1.3
+      pathe: 2.0.3
+      picomatch: 4.0.5
+      std-env: 4.2.0
+      tinybench: 2.9.0
+      tinyexec: 1.2.4
+      tinyglobby: 0.2.17
+      tinyrainbow: 3.1.0
+      vite: 6.3.5(@types/node@24.0.7)(jiti@2.4.2)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@types/node': 24.0.7
+      happy-dom: 20.10.6
+      jsdom: 29.1.1
+    transitivePeerDependencies:
+      - msw
+
+  w3c-xmlserializer@5.0.0:
+    dependencies:
+      xml-name-validator: 5.0.0
 
   watchpack@2.4.2:
     dependencies:
@@ -3938,7 +4601,21 @@ snapshots:
       - supports-color
       - utf-8-validate
 
+  webidl-conversions@8.0.1: {}
+
   webpack-virtual-modules@0.6.2: {}
+
+  whatwg-mimetype@3.0.0: {}
+
+  whatwg-mimetype@5.0.0: {}
+
+  whatwg-url@16.0.1:
+    dependencies:
+      '@exodus/bytes': 1.15.1
+      tr46: 6.0.0
+      webidl-conversions: 8.0.1
+    transitivePeerDependencies:
+      - '@noble/hashes'
 
   when-exit@2.1.4: {}
 
@@ -3952,6 +4629,11 @@ snapshots:
   which@2.0.2:
     dependencies:
       isexe: 2.0.0
+
+  why-is-node-running@2.3.0:
+    dependencies:
+      siginfo: 2.0.0
+      stackback: 0.0.2
 
   widest-line@5.0.0:
     dependencies:
@@ -3974,6 +4656,8 @@ snapshots:
   wrappy@1.0.2: {}
 
   ws@8.18.1: {}
+
+  ws@8.21.1: {}
 
   wxt@0.20.7(@types/node@24.0.7)(jiti@2.4.2)(rollup@4.44.1):
     dependencies:
@@ -4041,12 +4725,16 @@ snapshots:
 
   xdg-basedir@5.1.0: {}
 
+  xml-name-validator@5.0.0: {}
+
   xml2js@0.6.2:
     dependencies:
       sax: 1.4.1
       xmlbuilder: 11.0.1
 
   xmlbuilder@11.0.1: {}
+
+  xmlchars@2.2.0: {}
 
   y18n@5.0.8: {}
 

--- a/wxt-dev-wxt/pnpm-workspace.yaml
+++ b/wxt-dev-wxt/pnpm-workspace.yaml
@@ -1,0 +1,5 @@
+# pnpm 11 blocks dependency install/build scripts by default. esbuild links its
+# native binary in a postinstall; allow it (and spawn-sync) so the build works.
+allowBuilds:
+  esbuild: true
+  spawn-sync: true

--- a/wxt-dev-wxt/vitest.config.ts
+++ b/wxt-dev-wxt/vitest.config.ts
@@ -1,0 +1,15 @@
+import { defineConfig } from 'vitest/config';
+import { WxtVitest } from 'wxt/testing';
+
+// WxtVitest wires up WXT auto-imports, the `#imports` alias, an in-memory
+// fake-browser (incl. browser.storage), and the `@` path alias — so storage
+// and extension-API code can be tested without hand-rolled mocks.
+export default defineConfig({
+  plugins: [WxtVitest()],
+  test: {
+    // happy-dom rather than jsdom: jsdom replaces global Uint8Array/TextEncoder,
+    // which trips esbuild's startup invariant and made suites flakily fail to load.
+    environment: 'happy-dom',
+    include: ['entrypoints/**/*.{test,spec}.ts'],
+  },
+});


### PR DESCRIPTION
## Summary

Makes Epic and Steam auto-claiming reliable end-to-end, fixes a family of claim-flow hangs, and adds a test suite + build tooling. Originally motivated by the macOS "have to click Manually Claim several times" bug; grew to cover every modal Epic puts between "Get" and the order confirmation.

## What changed

**Claim reliability**
- Await the full claim chain so the MV3 service worker isn't killed mid-claim (root cause of the macOS multi-click bug); retry the content-script handshake instead of losing the claim on the first "Could not establish connection".
- Widen the Epic content-script matches to `www.epicgames.com/store/*` (canonical product links) so the script is actually injected on claim pages.
- Force `?lang=en-US` on Epic claim URLs and match modal buttons by text, so it works regardless of account language.
- Drive the claim to the order-confirmation screen through the full modal chain: **Device not supported** → **Add to library / Place Order** → EU **Right of Withdrawal ("I accept")** → **age-gate ("Continue", `#btn_age_continue`)** for mature games. Each confirmation is clicked once (re-clicking mid-transition was cancelling the purchase).
- Detect completion via `innerText` (the page embeds a localization JSON in a `<script>` that made `textContent` match the confirmation strings prematurely).

**Quality**
- Resolve all pre-existing `tsc --noEmit` errors (Browser type namespace, branded `StorageItemKey`, this-context extraction).
- Extract a shared `onClaimMessage` router for both content scripts; remove dead code (`clickWhenVisibleIframe`, `background.sendMessage`, unused import/branch); fix a mislabeled error log.

**Tooling / tests / docs**
- Vitest + happy-dom setup; `pnpm-workspace.yaml` allowBuilds so pnpm 11 stops blocking esbuild.
- 40 unit tests across claim logic, button/modal finders, storage wrapper, and enums.
- ECC onboarding docs + project `CLAUDE.md`.
- Version bumped to **2.4.0**.

## Test plan

- [x] `npm run compile` (tsc) — 0 errors
- [x] `npm test` — 40 passing
- [x] `npm run build` / `zip` / `zip:firefox` — clean
- [ ] Load unpacked `dist/chrome-mv3`, logged in to Epic + Steam, and claim: normal game, EU game (Right-of-Withdrawal), and an age-restricted game (e.g. OTXO) — console should reach `Claim completed` after the expected `Clicking:`/`Dismissing` lines.

## Notes

- Age-gate handling was verified against the live Epic DOM: `#btn_age_continue` is in the top document; the disabled date-of-birth variant (anonymous users) is intentionally skipped.
- History is grouped into reviewable Conventional commits; per repo convention this should land as a merge commit.
