### PR TITLE
fix: Epic product URLs, claim isolation, and the Firefox popup regression

### DIFF
--- a/wxt-dev-wxt/entrypoints/background.ts
+++ b/wxt-dev-wxt/entrypoints/background.ts
@@ -10,6 +10,12 @@ import {EpicElement, EpicKeyImage, EpicSearchResponse} from "@/entrypoints/types
 const EPIC_API_URL = "https://store-site-backend-static-ipv4.ak.epicgames.com/freeGamesPromotions?locale=en-US";
 const EPIC_GAMES_URL =
     "https://store.epicgames.com/";
+// Product pages are built on store.epicgames.com rather than
+// www.epicgames.com/store/...: the www form is a redirect, and Epic bounces
+// some slugs onto /site/... paths that 404 *and* fall outside the Epic content
+// script's match patterns, so the claim tab ends up with no script injected.
+const EPIC_PRODUCT_BASE = "https://store.epicgames.com/en-US";
+export const EPIC_FREE_GAMES_URL = "https://store.epicgames.com/en-US/free-games";
 const STEAM_GAMES_URL =
     "https://store.steampowered.com/search/?sort_by=Price_ASC&maxprice=free&category1=998&specials=1&ndl=1";
 
@@ -45,18 +51,65 @@ export function withEpicEnglishLocale(url: string): string {
   return url;
 }
 
+// Epic exposes the same product under several slug fields and they are not
+// interchangeable. `productSlug` is a legacy *path* that often carries a
+// "/home" suffix (e.g. "cardpocalypse/home"), which produces a 404 product URL;
+// the page-mapping tables carry the bare slug ("cardpocalypse"). Prefer those,
+// and normalise whatever we get so a stray path segment can never leak into the
+// URL again.
+export function resolveEpicSlug(game: EpicElement): string {
+  const candidates = [
+    ...(game.catalogNs?.mappings ?? []).map((m) => m?.pageSlug),
+    ...(game.offerMappings ?? []).map((m) => m?.pageSlug),
+    game.productSlug,
+  ];
+
+  for (const candidate of candidates) {
+    const slug = normalizeEpicSlug(candidate);
+    if (slug) return slug;
+  }
+  return "";
+}
+
+function normalizeEpicSlug(raw: string | undefined | null): string {
+  const trimmed = (raw ?? "").trim().replace(/^\/+|\/+$/g, "");
+  if (!trimmed) return "";
+  // "cardpocalypse/home" -> "cardpocalypse". Any other multi-segment slug is
+  // reduced to its first segment for the same reason: /p/ takes one segment.
+  return trimmed.split("/")[0] ?? "";
+}
+
+// Splits an Epic search payload into the games that are free right now and the
+// ones announced as free next. A game must appear in exactly one bucket — Epic
+// can report both a current and an upcoming free offer for the same title
+// during the weekly changeover, and listing it twice made the popup show
+// duplicates.
+export function partitionEpicPromotions(games: EpicElement[]): {
+  current: EpicElement[];
+  future: EpicElement[];
+} {
+  const current = games.filter((game) =>
+      game.price?.totalPrice?.discountPrice === 0 &&
+      (game.promotions?.promotionalOffers?.length ?? 0) > 0
+  );
+  const currentTitles = new Set(current.map((game) => game.title));
+
+  const future = games.filter((game) =>
+      !currentTitles.has(game.title) &&
+      game.promotions?.upcomingPromotionalOffers?.[0]?.promotionalOffers?.[0]
+          ?.discountSetting?.discountPercentage === 0
+  );
+
+  return { current, future };
+}
+
 export function formatEpicFreeGame(game: EpicElement, future: boolean): FreeGame {
-  const epicSlug =
-      game.productSlug ||
-      game.catalogNs?.mappings?.[0]?.pageSlug ||
-      game.offerMappings?.[0]?.pageSlug ||
-      "";
+  const slug = resolveEpicSlug(game);
 
   const isEpicBundle =
       Array.isArray(game.categories) &&
       game.categories.some((c) => c?.path === "bundles");
 
-  const slug = epicSlug;
   const path = isEpicBundle ? "bundle" : "p";
 
   const promo =
@@ -67,7 +120,9 @@ export function formatEpicFreeGame(game: EpicElement, future: boolean): FreeGame
   return {
     title: game.title ?? "",
     platform: Platforms.Epic,
-    link: `https://www.epicgames.com/store/en-US/${path}/${slug}`,
+    // No resolvable slug would mean a bare "/p/" 404, so fall back to the
+    // free-games hub: still claimable, and the content script runs there.
+    link: slug ? `${EPIC_PRODUCT_BASE}/${path}/${slug}` : EPIC_FREE_GAMES_URL,
     img:
         game.keyImages?.find((img: EpicKeyImage) => img.type === "Thumbnail")?.url ||
         game.keyImages?.[0]?.url ||
@@ -79,7 +134,7 @@ export function formatEpicFreeGame(game: EpicElement, future: boolean): FreeGame
   };
 }
 
-const background = {
+export const background = {
   async main() {
     browser.runtime.onStartup.addListener(() => this.handleStartup());
 
@@ -211,7 +266,13 @@ const background = {
   async claimGames(games: FreeGame[]) {
     void this.setBadgeText(games.length.toString());
     for (const game of games) {
-      await this.openTabAndSendActionToContent(withEpicEnglishLocale(game.link), "claimGames");
+      // One unreachable tab (404 product page, content script never injected,
+      // navigation error) must not cancel the remaining claims.
+      try {
+        await this.openTabAndSendActionToContent(withEpicEnglishLocale(game.link), "claimGames");
+      } catch (e) {
+        console.error(`claimGames: failed to claim "${game.title}" (${game.link})`, e);
+      }
       await this.wait(10_000);
     }
   },
@@ -348,31 +409,22 @@ const background = {
 
     const games: EpicElement[] = data?.data?.Catalog?.searchStore?.elements ?? [];
 
-    const freeGames = games.filter((game) =>
-        game.price?.totalPrice?.discountPrice === 0 &&
-        (game.promotions?.promotionalOffers?.length ?? 0) > 0
-    );
-
-    const futureFreeGames = games.filter((game) =>
-        game.promotions?.upcomingPromotionalOffers?.[0]?.promotionalOffers?.[0]?.discountSetting?.discountPercentage === 0
-    );
+    const { current: freeGames, future: futureFreeGames } = partitionEpicPromotions(games);
 
     const currFreeGames: FreeGame[] = await getStorageItem("epicGames") || [];
     const newGames = freeGames.filter((game) =>
         !currFreeGames.some((g) => g?.title === game?.title)
     );
 
-    if (newGames.length > 0) {
-      const formattedNewGames = newGames.map(g => formatEpicFreeGame(g, false));
+    // Both lists are persisted before any claiming happens, and both are written
+    // unconditionally. Claiming used to sit between the two writes, so a failed
+    // claim aborted the futureGames refresh and left last week's "upcoming"
+    // entry next to this week's free entry in the popup.
+    await setStorageItem("epicGames", freeGames.map(g => formatEpicFreeGame(g, false)));
+    await setStorageItem("futureGames", futureFreeGames.map(g => formatEpicFreeGame(g, true)));
 
-      await setStorageItem("epicGames", formattedNewGames);
-      if (shouldClaim) await this.claimGames(formattedNewGames);
-    }
-
-    if (futureFreeGames.length > 0) {
-      const formattedFutureGames = futureFreeGames.map(g => formatEpicFreeGame(g, true));
-
-      await setStorageItem("futureGames", formattedFutureGames);
+    if (shouldClaim && newGames.length > 0) {
+      await this.claimGames(newGames.map(g => formatEpicFreeGame(g, false)));
     }
   },
 

--- a/wxt-dev-wxt/entrypoints/tests/background.test.ts
+++ b/wxt-dev-wxt/entrypoints/tests/background.test.ts
@@ -3,7 +3,16 @@
 // as a duplicate "background" entrypoint. Node env avoids the esbuild/jsdom clash
 // from importing background.ts (which pulls in `#imports`).
 import { describe, it, expect } from 'vitest';
-import { areDatesDifferent, didEnoughTimePass, formatEpicFreeGame, withEpicEnglishLocale } from '../background';
+import {
+  areDatesDifferent,
+  background,
+  didEnoughTimePass,
+  EPIC_FREE_GAMES_URL,
+  formatEpicFreeGame,
+  partitionEpicPromotions,
+  resolveEpicSlug,
+  withEpicEnglishLocale,
+} from '../background';
 import { Platforms } from '../enums/platforms';
 
 describe('areDatesDifferent', () => {
@@ -49,7 +58,7 @@ describe('formatEpicFreeGame', () => {
     const game = formatEpicFreeGame(el, false);
     expect(game.title).toBe('Test Game');
     expect(game.platform).toBe(Platforms.Epic);
-    expect(game.link).toBe('https://www.epicgames.com/store/en-US/p/test-game');
+    expect(game.link).toBe('https://store.epicgames.com/en-US/p/test-game');
     expect(game.img).toBe('https://img/thumb.jpg');
     expect(game.future).toBe(false);
     expect(game.endDate).toBe('2026-01-08T00:00:00.000Z');
@@ -80,5 +89,121 @@ describe('withEpicEnglishLocale', () => {
   it('leaves non-Epic URLs unchanged', () => {
     const steam = 'https://store.steampowered.com/app/1/';
     expect(withEpicEnglishLocale(steam)).toBe(steam);
+  });
+});
+
+describe('resolveEpicSlug', () => {
+  it('prefers the catalogNs pageSlug over a productSlug carrying a /home suffix', () => {
+    const el = {
+      productSlug: 'cardpocalypse/home',
+      catalogNs: { mappings: [{ pageSlug: 'cardpocalypse' }] },
+    } as any;
+    expect(resolveEpicSlug(el)).toBe('cardpocalypse');
+  });
+
+  it('strips a trailing /home segment when only productSlug is present', () => {
+    expect(resolveEpicSlug({ productSlug: 'cardpocalypse/home' } as any)).toBe('cardpocalypse');
+  });
+
+  it('strips surrounding slashes', () => {
+    expect(resolveEpicSlug({ productSlug: '/some-game/' } as any)).toBe('some-game');
+  });
+
+  it('falls back to offerMappings when catalogNs has no usable slug', () => {
+    const el = {
+      catalogNs: { mappings: [{}] },
+      offerMappings: [{ pageSlug: 'from-offer' }],
+    } as any;
+    expect(resolveEpicSlug(el)).toBe('from-offer');
+  });
+
+  it('returns an empty string when no slug is available', () => {
+    expect(resolveEpicSlug({ title: 'X' } as any)).toBe('');
+  });
+});
+
+describe('formatEpicFreeGame link building', () => {
+  it('builds a store.epicgames.com product URL for the real Cardpocalypse payload', () => {
+    const el = {
+      title: 'Cardpocalypse Standard Edition',
+      productSlug: 'cardpocalypse/home',
+      urlSlug: 'cardpocalypsegeneralaudience',
+      catalogNs: { mappings: [{ pageSlug: 'cardpocalypse' }] },
+      offerMappings: [{ pageSlug: 'cardpocalypse' }],
+      categories: [{ path: 'freegames' }, { path: 'games' }],
+    } as any;
+    expect(formatEpicFreeGame(el, false).link).toBe('https://store.epicgames.com/en-US/p/cardpocalypse');
+  });
+
+  it('never emits a link with an empty slug', () => {
+    const link = formatEpicFreeGame({ title: 'X' } as any, false).link;
+    expect(link).not.toMatch(/\/p\/?$/);
+    expect(link).toBe(EPIC_FREE_GAMES_URL);
+  });
+});
+
+describe('partitionEpicPromotions', () => {
+  const currentlyFree = {
+    title: 'Cardpocalypse Standard Edition',
+    price: { totalPrice: { discountPrice: 0 } },
+    promotions: {
+      promotionalOffers: [{ promotionalOffers: [{ discountSetting: { discountPercentage: 0 } }] }],
+    },
+  } as any;
+
+  const upcomingFree = {
+    title: 'Breathedge',
+    price: { totalPrice: { discountPrice: 2499 } },
+    promotions: {
+      upcomingPromotionalOffers: [{ promotionalOffers: [{ discountSetting: { discountPercentage: 0 } }] }],
+    },
+  } as any;
+
+  const upcomingDiscount = {
+    title: 'Ghostrunner 2',
+    price: { totalPrice: { discountPrice: 3999 } },
+    promotions: {
+      upcomingPromotionalOffers: [{ promotionalOffers: [{ discountSetting: { discountPercentage: 20 } }] }],
+    },
+  } as any;
+
+  it('splits current and upcoming free games', () => {
+    const { current, future } = partitionEpicPromotions([currentlyFree, upcomingFree, upcomingDiscount]);
+    expect(current.map((g) => g.title)).toEqual(['Cardpocalypse Standard Edition']);
+    expect(future.map((g) => g.title)).toEqual(['Breathedge']);
+  });
+
+  it('never lists a currently free game as upcoming', () => {
+    const alsoUpcoming = {
+      ...currentlyFree,
+      promotions: {
+        ...currentlyFree.promotions,
+        upcomingPromotionalOffers: [{ promotionalOffers: [{ discountSetting: { discountPercentage: 0 } }] }],
+      },
+    } as any;
+    const { current, future } = partitionEpicPromotions([alsoUpcoming]);
+    expect(current).toHaveLength(1);
+    expect(future).toEqual([]);
+  });
+});
+
+describe('claimGames resilience', () => {
+  it('opens every game even when an earlier claim throws', async () => {
+    const opened: string[] = [];
+    const runner = Object.create(background);
+    runner.openTabAndSendActionToContent = async (url: string) => {
+      opened.push(url);
+      if (opened.length === 1) throw new Error('Receiving end does not exist');
+    };
+    runner.wait = async () => {};
+    runner.setBadgeText = async () => {};
+
+    await runner.claimGames([
+      { title: 'A', platform: Platforms.Epic, link: 'https://store.epicgames.com/en-US/p/a' },
+      { title: 'B', platform: Platforms.Epic, link: 'https://store.epicgames.com/en-US/p/b' },
+    ] as any);
+
+    expect(opened).toHaveLength(2);
+    expect(opened[1]).toContain('/p/b');
   });
 });


### PR DESCRIPTION
## Problem

This week's Epic weekly free game (**Cardpocalypse**) could not be claimed. Three defects, one causal chain:

1. **Wrong product URL.** The extension opened `https://www.epicgames.com/site/p/cardpocalypse/home?lang=en-US`, which 404s, instead of `https://store.epicgames.com/p/cardpocalypse`.
2. **A failed claim cancelled the rest.** When the first game failed, the second (Albion's *Epic Mage Bundle*) was never opened.
3. **Duplicate popup entries.** The same title was listed both as a free game and as an upcoming free game.

## Root causes

**1. Slug selection.** Epic returns two non-interchangeable slugs for the same product:

```json
"productSlug": "cardpocalypse/home",
"catalogNs": { "mappings": [{ "pageSlug": "cardpocalypse", "pageType": "productHome" }] }
```

`formatEpicFreeGame` preferred `productSlug`, building `.../p/cardpocalypse/home`. Epic bounces that onto `/site/p/cardpocalypse/home` — a 404 that also matches **neither** pattern in `epic.content.ts`, so no content script was ever injected into the claim tab.

**2. No per-game isolation.** `claimGames`' loop had no error handling. `sendMessageWithRetry` throws when nothing answers — precisely what (1) produced — and the throw escaped the `for`, killing every remaining claim.

**3. Write ordering.** `claimGames` sat *between* the `epicGames` write and the `futureGames` write in `getEpicGamesList`. (2)'s throw aborted the function before `futureGames` was refreshed, so last week's list — where Cardpocalypse was still *upcoming* — survived alongside this week's free entry. `GamesList.tsx` concatenates both lists. Contributing: the future filter never excluded already-free titles, and `futureGames` was only written when non-empty, so it was never cleared.

## Changes

- **`resolveEpicSlug()`** — prefers `catalogNs.mappings` / `offerMappings` page slugs over the legacy `productSlug`, and normalises any slug down to a single path segment so a stray segment can't leak into a URL again.
- Product links are built on `store.epicgames.com/en-US/...` directly. The `www.epicgames.com/store/...` form is a redirect, and that redirect is where the `/site/` detour happened. Both hosts are already covered by the content script's match patterns.
- An unresolvable slug now falls back to the free-games hub instead of emitting a bare `/p/` 404.
- **`claimGames`** — each iteration wrapped in try/catch with a logged failure, so one unreachable tab no longer cancels the rest.
- **`partitionEpicPromotions()`** — single source of truth for the current/upcoming split, and it guarantees a currently free title never lands in the future bucket.
- **`getEpicGamesList`** — both lists are persisted *before* any claiming, unconditionally, so an empty future list clears stale data.

## Test plan

- [x] `npm run compile` — clean, 0 errors
- [x] `npm test` — 50 passed (10 new tests, written failing first per TDD)
- [x] `npm run build` (Chrome MV3) and `npm run build:firefox` (Firefox MV2) — both succeed
- [x] Replayed today's live `freeGamesPromotions` payload through the new code: `Cardpocalypse Standard Edition -> https://store.epicgames.com/en-US/p/cardpocalypse`, and the future bucket correctly holds only Breathedge + Rival Stars
- [ ] **Manual, not yet done:** load the unpacked build and confirm an end-to-end claim. Cloudflare's bot check blocks automated browsing of Epic pages, so URL correctness is verified against the live API payload and the reported working link — not against a real claim.

## Notes for the reviewer

- **Existing installs won't auto-claim Cardpocalypse.** It's already in stored `epicGames`, so the "new games" dedupe skips it. One press of the manual claim button (which clears the lists first) picks it up with the corrected URL.
- **Albion's *Epic Mage Bundle*** is an `ADD_ON`. Its `catalogNs` slug points at the base game page (`albion-online-7eb24d`) while `offerMappings` holds the offer page (`albion-online-epic-mage-bundle-2ceb19`). This PR preserves the existing behaviour there — it linked to the base game before too. If that add-on also fails to claim, preferring `pageType: "offer"` mappings for add-ons is the follow-up; I didn't do it speculatively since I can't verify which page actually claims.
- `epicGames` now stores the full current free list rather than only the newly-seen subset. That was needed so a week rollover can't leave a stale title behind; claiming is still limited to newly-seen games.

---

## Added: Firefox popup regression (cherry-pick of `3739e81`)

The 2.6.0 Firefox build opened as an empty zero-height strip. Root cause: the Firefox target is Manifest V2, which exposes the toolbar button as `browser.browserAction` — `browser.action` exists only under MV3. `App.tsx` read `browser.action.setBadgeText` in the **render body**, so every popup open threw a `TypeError`, React tore the tree down, and the popup collapsed. `background.ts` hit the same wall on install and on every badge update. Confirmed in the shipped 2.6.0 Firefox bundle: `action.setBadgeText` present, zero `browserAction` references.

This was already fixed on the unmerged `feat/gog-giveaway` branch; `3739e81` is cherry-picked here so it reaches `main`. The `steamReviews` import in that commit was dropped during conflict resolution — that module ships with the separate, still-unmerged Steam review-gate work.

Both badge call sites now route through `utils/badge.ts`, which resolves `browser.action ?? browser.browserAction` and no-ops with a warning if neither exists, and the popup clears its badge in an effect rather than during render.

- [x] `npm run compile` clean, **54** tests pass (4 new badge tests)
- [x] Verified in both 2.6.1 zips: `browserAction` fallback present in `background.js` and the popup chunk
- [ ] **Manual:** load the 2.6.1 Firefox zip and confirm the popup renders
