### PR TITLE
fix: render the Firefox popup by falling back to browserAction (2.6.1)

### DIFF
--- a/wxt-dev-wxt/entrypoints/background.ts
+++ b/wxt-dev-wxt/entrypoints/background.ts
@@ -4,6 +4,10 @@ import {FreeGame} from "@/entrypoints/types/freeGame.ts";
 import {Platforms} from "@/entrypoints/enums/platforms.ts";
 import {ClaimFrequency, ClaimFrequencyMinutes} from "@/entrypoints/enums/claimFrequency.ts";
 import {parse} from 'node-html-parser';
+import {
+  setBadgeBackgroundColor as setActionBadgeBackgroundColor,
+  setBadgeText as setActionBadgeText,
+} from "@/entrypoints/utils/badge.ts";
 import {browser, type Browser} from "wxt/browser";
 import {EpicElement, EpicKeyImage, EpicSearchResponse} from "@/entrypoints/types/epicGame.ts";
 
@@ -394,7 +398,7 @@ export const background = {
 
   handleInstall(r: Browser.runtime.InstalledDetails) {
     if (r.reason === "update") {
-      browser.action.setBadgeBackgroundColor({ color: "#50ca26" });
+      void setActionBadgeBackgroundColor("#50ca26");
       void this.setBadgeText("New");
     }
   },
@@ -482,7 +486,7 @@ export const background = {
   },
 
   async setBadgeText(text: string) {
-    await browser.action.setBadgeText({ text });
+    await setActionBadgeText(text);
   }
 };
 

--- a/wxt-dev-wxt/entrypoints/popup/App.tsx
+++ b/wxt-dev-wxt/entrypoints/popup/App.tsx
@@ -1,4 +1,6 @@
 import './App.css';
+import {useEffect} from "react";
+import {setBadgeText} from "@/entrypoints/utils/badge.ts";
 import {useStorage} from "@/entrypoints/hooks/useStorage.ts";
 import GamesList from "@/entrypoints/components/GamesList.tsx";
 import {ActiveTabs} from "@/entrypoints/enums/activeTabs.ts";
@@ -6,8 +8,13 @@ import Settings from "@/entrypoints/components/Settings.tsx";
 import Footer from "@/entrypoints/components/Footer.tsx";
 
 function App() {
-    clearBadge();
     const [activeTab, setActiveTab] = useStorage<ActiveTabs>("activeTab", ActiveTabs.MAIN);
+
+    // In an effect, not the render body: a throw here used to take the whole
+    // popup down with it, and clearing the badge is a side effect either way.
+    useEffect(() => {
+        void setBadgeText("");
+    }, []);
 
     return (
         <div className="App">
@@ -31,10 +38,6 @@ function App() {
             <Footer/>
         </div>
     );
-
-    function clearBadge() {
-        browser.action.setBadgeText({ text: "" });
-    }
 }
 
 export default App;

--- a/wxt-dev-wxt/entrypoints/utils/badge.test.ts
+++ b/wxt-dev-wxt/entrypoints/utils/badge.test.ts
@@ -1,0 +1,34 @@
+import { describe, it, expect, vi } from 'vitest';
+import { resolveActionApi } from './badge';
+
+function apiStub() {
+  return {
+    setBadgeText: vi.fn(),
+    setBadgeBackgroundColor: vi.fn(),
+  };
+}
+
+describe('resolveActionApi', () => {
+  it('uses browser.action under Manifest V3', () => {
+    const action = apiStub();
+
+    expect(resolveActionApi({ action })).toBe(action);
+  });
+
+  it('falls back to browser.browserAction under Firefox Manifest V2', () => {
+    const browserAction = apiStub();
+
+    expect(resolveActionApi({ browserAction })).toBe(browserAction);
+  });
+
+  it('prefers browser.action when both namespaces exist', () => {
+    const action = apiStub();
+    const browserAction = apiStub();
+
+    expect(resolveActionApi({ action, browserAction })).toBe(action);
+  });
+
+  it('is undefined when neither namespace exists', () => {
+    expect(resolveActionApi({})).toBeUndefined();
+  });
+});

--- a/wxt-dev-wxt/entrypoints/utils/badge.ts
+++ b/wxt-dev-wxt/entrypoints/utils/badge.ts
@@ -1,0 +1,48 @@
+// Toolbar-button (badge) access that works on both build targets.
+//
+// The Chrome build is Manifest V3 and exposes `browser.action`; the Firefox
+// build is Manifest V2 and exposes `browser.browserAction` instead — there is
+// no `action` namespace at all. Touching `browser.action.setBadgeText` on
+// Firefox therefore threw a TypeError, and because the popup did it during
+// render, React tore the whole tree down and the popup opened as an empty,
+// zero-height strip.
+
+interface BadgeTextDetails {
+    text: string;
+}
+
+interface BadgeColorDetails {
+    color: string;
+}
+
+export interface ActionApi {
+    setBadgeText(details: BadgeTextDetails): Promise<void> | void;
+    setBadgeBackgroundColor(details: BadgeColorDetails): Promise<void> | void;
+}
+
+export interface ActionNamespaces {
+    action?: ActionApi;
+    browserAction?: ActionApi;
+}
+
+export function resolveActionApi(namespaces: ActionNamespaces): ActionApi | undefined {
+    return namespaces.action ?? namespaces.browserAction;
+}
+
+// The badge is decoration: a browser that offers neither namespace must not be
+// able to break a claim run or blank the popup, so we warn and carry on.
+function getActionApi(): ActionApi | undefined {
+    const api = resolveActionApi(browser as unknown as ActionNamespaces);
+    if (!api) {
+        console.warn("[badge] no action/browserAction namespace available; skipping badge update");
+    }
+    return api;
+}
+
+export async function setBadgeText(text: string): Promise<void> {
+    await getActionApi()?.setBadgeText({ text });
+}
+
+export async function setBadgeBackgroundColor(color: string): Promise<void> {
+    await getActionApi()?.setBadgeBackgroundColor({ color });
+}

--- a/wxt-dev-wxt/package-lock.json
+++ b/wxt-dev-wxt/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "free-game-claimer-for-steam-epic",
-  "version": "2.4.0",
+  "version": "2.6.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "free-game-claimer-for-steam-epic",
-      "version": "2.4.0",
+      "version": "2.6.1",
       "hasInstallScript": true,
       "dependencies": {
         "node-html-parser": "^7.0.1",

--- a/wxt-dev-wxt/package.json
+++ b/wxt-dev-wxt/package.json
@@ -2,7 +2,7 @@
   "name": "free-game-claimer-for-steam-epic",
   "description": "script to claim free games on Epic Games Store",
   "private": false,
-  "version": "2.4.0",
+  "version": "2.6.1",
   "type": "module",
   "scripts": {
     "dev": "wxt",


### PR DESCRIPTION
## Problem

The Firefox build's popup opens as an empty zero-height strip.

## Root cause

The Firefox target is **Manifest V2**, which exposes the toolbar button as `browser.browserAction` — `browser.action` exists only under MV3. `App.tsx` read `browser.action.setBadgeText` in the **render body**, so every popup open threw a `TypeError`, React tore the tree down, and the popup collapsed. `background.ts` hit the same wall on install and on every badge update.

Confirmed in the built 2.6.0 Firefox bundle before fixing: `action.setBadgeText` present, **zero** `browserAction` references.

## Why this regressed

This was fixed once already, in `3739e81` on the still-unmerged `feat/gog-giveaway` branch — it never reached `main`. #22 was cut from `main`, so the release built from it reintroduced the bug. This PR cherry-picks that commit so the fix finally lands on `main`.

The `steamReviews` import in the original commit was dropped during conflict resolution — that module ships with the separate, still-unmerged Steam review-gate work.

## Changes

- New `utils/badge.ts` resolving `browser.action ?? browser.browserAction`, no-opping with a warning if neither exists. The badge is decoration and must not be able to break a claim run or blank the popup.
- Both badge call sites in `background.ts` route through it.
- The popup clears its badge in a `useEffect` rather than during render, so a throw there can no longer take the tree down.
- Version bumped to **2.6.1**.

Firefox MV3 was rejected as the alternative: it makes `host_permissions` opt-in rather than granted at install, which would silently break claiming.

## Test plan

- [x] `npm run compile` — clean, 0 errors
- [x] `npm test` — 54 pass (4 new `resolveActionApi` tests covering MV3, MV2, both-present, neither-present)
- [x] `npm run build` (Chrome MV3) and `npm run build:firefox` (Firefox MV2) — both succeed
- [x] Verified in both 2.6.1 zips: `browserAction` fallback present in `background.js` and the popup chunk
- [ ] **Manual, not yet done:** load the 2.6.1 Firefox zip and confirm the popup renders at full height

## Note

`main` was still at 2.4.0 — the version bump intended for #22 was pushed after that PR had already been merged and closed, so it never landed. This PR carries it.